### PR TITLE
Fix cars.json date issue

### DIFF
--- a/data/cars.json
+++ b/data/cars.json
@@ -7,7 +7,7 @@
       "Horsepower":130,
       "Weight_in_lbs":3504,
       "Acceleration":12,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -18,7 +18,7 @@
       "Horsepower":165,
       "Weight_in_lbs":3693,
       "Acceleration":11.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -29,7 +29,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3436,
       "Acceleration":11,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -40,7 +40,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3433,
       "Acceleration":12,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -51,7 +51,7 @@
       "Horsepower":140,
       "Weight_in_lbs":3449,
       "Acceleration":10.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -62,7 +62,7 @@
       "Horsepower":198,
       "Weight_in_lbs":4341,
       "Acceleration":10,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -73,7 +73,7 @@
       "Horsepower":220,
       "Weight_in_lbs":4354,
       "Acceleration":9,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -84,7 +84,7 @@
       "Horsepower":215,
       "Weight_in_lbs":4312,
       "Acceleration":8.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -95,7 +95,7 @@
       "Horsepower":225,
       "Weight_in_lbs":4425,
       "Acceleration":10,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -106,7 +106,7 @@
       "Horsepower":190,
       "Weight_in_lbs":3850,
       "Acceleration":8.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -117,7 +117,7 @@
       "Horsepower":115,
       "Weight_in_lbs":3090,
       "Acceleration":17.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -128,7 +128,7 @@
       "Horsepower":165,
       "Weight_in_lbs":4142,
       "Acceleration":11.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -139,7 +139,7 @@
       "Horsepower":153,
       "Weight_in_lbs":4034,
       "Acceleration":11,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -150,7 +150,7 @@
       "Horsepower":175,
       "Weight_in_lbs":4166,
       "Acceleration":10.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -161,7 +161,7 @@
       "Horsepower":175,
       "Weight_in_lbs":3850,
       "Acceleration":11,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -172,7 +172,7 @@
       "Horsepower":170,
       "Weight_in_lbs":3563,
       "Acceleration":10,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -183,7 +183,7 @@
       "Horsepower":160,
       "Weight_in_lbs":3609,
       "Acceleration":8,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -194,7 +194,7 @@
       "Horsepower":140,
       "Weight_in_lbs":3353,
       "Acceleration":8,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -205,7 +205,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3761,
       "Acceleration":9.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -216,7 +216,7 @@
       "Horsepower":225,
       "Weight_in_lbs":3086,
       "Acceleration":10,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -227,7 +227,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2372,
       "Acceleration":15,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Japan"
    },
    {
@@ -238,7 +238,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2833,
       "Acceleration":15.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -249,7 +249,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2774,
       "Acceleration":15.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -260,7 +260,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2587,
       "Acceleration":16,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -271,7 +271,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2130,
       "Acceleration":14.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Japan"
    },
    {
@@ -282,7 +282,7 @@
       "Horsepower":46,
       "Weight_in_lbs":1835,
       "Acceleration":20.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -293,7 +293,7 @@
       "Horsepower":87,
       "Weight_in_lbs":2672,
       "Acceleration":17.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -304,7 +304,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2430,
       "Acceleration":14.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -315,7 +315,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2375,
       "Acceleration":17.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -326,7 +326,7 @@
       "Horsepower":113,
       "Weight_in_lbs":2234,
       "Acceleration":12.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"Europe"
    },
    {
@@ -337,7 +337,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2648,
       "Acceleration":15,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -348,7 +348,7 @@
       "Horsepower":215,
       "Weight_in_lbs":4615,
       "Acceleration":14,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -359,7 +359,7 @@
       "Horsepower":200,
       "Weight_in_lbs":4376,
       "Acceleration":15,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -370,7 +370,7 @@
       "Horsepower":210,
       "Weight_in_lbs":4382,
       "Acceleration":13.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -381,7 +381,7 @@
       "Horsepower":193,
       "Weight_in_lbs":4732,
       "Acceleration":18.5,
-      "Year":1970,
+      "Year":"1970-01-01",
       "Origin":"USA"
    },
    {
@@ -392,7 +392,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2130,
       "Acceleration":14.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Japan"
    },
    {
@@ -403,7 +403,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2264,
       "Acceleration":15.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -414,7 +414,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2228,
       "Acceleration":14,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Japan"
    },
    {
@@ -425,7 +425,7 @@
       "Horsepower":null,
       "Weight_in_lbs":2046,
       "Acceleration":19,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -436,7 +436,7 @@
       "Horsepower":48,
       "Weight_in_lbs":1978,
       "Acceleration":20,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Europe"
    },
    {
@@ -447,7 +447,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2634,
       "Acceleration":13,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -458,7 +458,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3439,
       "Acceleration":15.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -469,7 +469,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3329,
       "Acceleration":15.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -480,7 +480,7 @@
       "Horsepower":88,
       "Weight_in_lbs":3302,
       "Acceleration":15.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -491,7 +491,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3288,
       "Acceleration":15.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -502,7 +502,7 @@
       "Horsepower":165,
       "Weight_in_lbs":4209,
       "Acceleration":12,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -513,7 +513,7 @@
       "Horsepower":175,
       "Weight_in_lbs":4464,
       "Acceleration":11.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -524,7 +524,7 @@
       "Horsepower":153,
       "Weight_in_lbs":4154,
       "Acceleration":13.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -535,7 +535,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4096,
       "Acceleration":13,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -546,7 +546,7 @@
       "Horsepower":180,
       "Weight_in_lbs":4955,
       "Acceleration":11.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -557,7 +557,7 @@
       "Horsepower":170,
       "Weight_in_lbs":4746,
       "Acceleration":12,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -568,7 +568,7 @@
       "Horsepower":175,
       "Weight_in_lbs":5140,
       "Acceleration":12,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -579,7 +579,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2962,
       "Acceleration":13.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -590,7 +590,7 @@
       "Horsepower":72,
       "Weight_in_lbs":2408,
       "Acceleration":19,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -601,7 +601,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3282,
       "Acceleration":15,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -612,7 +612,7 @@
       "Horsepower":88,
       "Weight_in_lbs":3139,
       "Acceleration":14.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -623,7 +623,7 @@
       "Horsepower":86,
       "Weight_in_lbs":2220,
       "Acceleration":14,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -634,7 +634,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2123,
       "Acceleration":14,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Europe"
    },
    {
@@ -645,7 +645,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2074,
       "Acceleration":19.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Europe"
    },
    {
@@ -656,7 +656,7 @@
       "Horsepower":76,
       "Weight_in_lbs":2065,
       "Acceleration":14.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Europe"
    },
    {
@@ -667,7 +667,7 @@
       "Horsepower":65,
       "Weight_in_lbs":1773,
       "Acceleration":19,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Japan"
    },
    {
@@ -678,7 +678,7 @@
       "Horsepower":69,
       "Weight_in_lbs":1613,
       "Acceleration":18,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Japan"
    },
    {
@@ -689,7 +689,7 @@
       "Horsepower":60,
       "Weight_in_lbs":1834,
       "Acceleration":19,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"Europe"
    },
    {
@@ -700,7 +700,7 @@
       "Horsepower":70,
       "Weight_in_lbs":1955,
       "Acceleration":20.5,
-      "Year":1971,
+      "Year":"1971-01-01",
       "Origin":"USA"
    },
    {
@@ -711,7 +711,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2278,
       "Acceleration":15.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Japan"
    },
    {
@@ -722,7 +722,7 @@
       "Horsepower":80,
       "Weight_in_lbs":2126,
       "Acceleration":17,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -733,7 +733,7 @@
       "Horsepower":54,
       "Weight_in_lbs":2254,
       "Acceleration":23.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Europe"
    },
    {
@@ -744,7 +744,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2408,
       "Acceleration":19.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -755,7 +755,7 @@
       "Horsepower":86,
       "Weight_in_lbs":2226,
       "Acceleration":16.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -766,7 +766,7 @@
       "Horsepower":165,
       "Weight_in_lbs":4274,
       "Acceleration":12,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -777,7 +777,7 @@
       "Horsepower":175,
       "Weight_in_lbs":4385,
       "Acceleration":12,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -788,7 +788,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4135,
       "Acceleration":13.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -799,7 +799,7 @@
       "Horsepower":153,
       "Weight_in_lbs":4129,
       "Acceleration":13,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -810,7 +810,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3672,
       "Acceleration":11.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -821,7 +821,7 @@
       "Horsepower":208,
       "Weight_in_lbs":4633,
       "Acceleration":11,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -832,7 +832,7 @@
       "Horsepower":155,
       "Weight_in_lbs":4502,
       "Acceleration":13.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -843,7 +843,7 @@
       "Horsepower":160,
       "Weight_in_lbs":4456,
       "Acceleration":13.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -854,7 +854,7 @@
       "Horsepower":190,
       "Weight_in_lbs":4422,
       "Acceleration":12.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -865,7 +865,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2330,
       "Acceleration":13.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Japan"
    },
    {
@@ -876,7 +876,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3892,
       "Acceleration":12.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -887,7 +887,7 @@
       "Horsepower":130,
       "Weight_in_lbs":4098,
       "Acceleration":14,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -898,7 +898,7 @@
       "Horsepower":140,
       "Weight_in_lbs":4294,
       "Acceleration":16,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -909,7 +909,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4077,
       "Acceleration":14,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -920,7 +920,7 @@
       "Horsepower":112,
       "Weight_in_lbs":2933,
       "Acceleration":14.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Europe"
    },
    {
@@ -931,7 +931,7 @@
       "Horsepower":76,
       "Weight_in_lbs":2511,
       "Acceleration":18,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Europe"
    },
    {
@@ -942,7 +942,7 @@
       "Horsepower":87,
       "Weight_in_lbs":2979,
       "Acceleration":19.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Europe"
    },
    {
@@ -953,7 +953,7 @@
       "Horsepower":69,
       "Weight_in_lbs":2189,
       "Acceleration":18,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Europe"
    },
    {
@@ -964,7 +964,7 @@
       "Horsepower":86,
       "Weight_in_lbs":2395,
       "Acceleration":16,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -975,7 +975,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2288,
       "Acceleration":17,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Japan"
    },
    {
@@ -986,7 +986,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2506,
       "Acceleration":14.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Japan"
    },
    {
@@ -997,7 +997,7 @@
       "Horsepower":80,
       "Weight_in_lbs":2164,
       "Acceleration":15,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"USA"
    },
    {
@@ -1008,7 +1008,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2100,
       "Acceleration":16.5,
-      "Year":1972,
+      "Year":"1972-01-01",
       "Origin":"Japan"
    },
    {
@@ -1019,7 +1019,7 @@
       "Horsepower":175,
       "Weight_in_lbs":4100,
       "Acceleration":13,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1030,7 +1030,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3672,
       "Acceleration":11.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1041,7 +1041,7 @@
       "Horsepower":145,
       "Weight_in_lbs":3988,
       "Acceleration":13,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1052,7 +1052,7 @@
       "Horsepower":137,
       "Weight_in_lbs":4042,
       "Acceleration":14.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1063,7 +1063,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3777,
       "Acceleration":12.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1074,7 +1074,7 @@
       "Horsepower":198,
       "Weight_in_lbs":4952,
       "Acceleration":11.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1085,7 +1085,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4464,
       "Acceleration":12,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1096,7 +1096,7 @@
       "Horsepower":158,
       "Weight_in_lbs":4363,
       "Acceleration":13,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1107,7 +1107,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4237,
       "Acceleration":14.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1118,7 +1118,7 @@
       "Horsepower":215,
       "Weight_in_lbs":4735,
       "Acceleration":11,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1129,7 +1129,7 @@
       "Horsepower":225,
       "Weight_in_lbs":4951,
       "Acceleration":11,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1140,7 +1140,7 @@
       "Horsepower":175,
       "Weight_in_lbs":3821,
       "Acceleration":11,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1151,7 +1151,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3121,
       "Acceleration":16.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1162,7 +1162,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3278,
       "Acceleration":18,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1173,7 +1173,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2945,
       "Acceleration":16,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1184,7 +1184,7 @@
       "Horsepower":88,
       "Weight_in_lbs":3021,
       "Acceleration":16.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1195,7 +1195,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2904,
       "Acceleration":16,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1206,7 +1206,7 @@
       "Horsepower":46,
       "Weight_in_lbs":1950,
       "Acceleration":21,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1217,7 +1217,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4997,
       "Acceleration":14,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1228,7 +1228,7 @@
       "Horsepower":167,
       "Weight_in_lbs":4906,
       "Acceleration":12.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1239,7 +1239,7 @@
       "Horsepower":170,
       "Weight_in_lbs":4654,
       "Acceleration":13,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1250,7 +1250,7 @@
       "Horsepower":180,
       "Weight_in_lbs":4499,
       "Acceleration":12.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1261,7 +1261,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2789,
       "Acceleration":15,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1272,7 +1272,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2279,
       "Acceleration":19,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Japan"
    },
    {
@@ -1283,7 +1283,7 @@
       "Horsepower":72,
       "Weight_in_lbs":2401,
       "Acceleration":19.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1294,7 +1294,7 @@
       "Horsepower":94,
       "Weight_in_lbs":2379,
       "Acceleration":16.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Japan"
    },
    {
@@ -1305,7 +1305,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2124,
       "Acceleration":13.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Japan"
    },
    {
@@ -1316,7 +1316,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2310,
       "Acceleration":18.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1327,7 +1327,7 @@
       "Horsepower":107,
       "Weight_in_lbs":2472,
       "Acceleration":14,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1338,7 +1338,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2265,
       "Acceleration":15.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1349,7 +1349,7 @@
       "Horsepower":145,
       "Weight_in_lbs":4082,
       "Acceleration":13,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1360,7 +1360,7 @@
       "Horsepower":230,
       "Weight_in_lbs":4278,
       "Acceleration":9.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1371,7 +1371,7 @@
       "Horsepower":49,
       "Weight_in_lbs":1867,
       "Acceleration":19.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1382,7 +1382,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2158,
       "Acceleration":15.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1393,7 +1393,7 @@
       "Horsepower":91,
       "Weight_in_lbs":2582,
       "Acceleration":14,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1404,7 +1404,7 @@
       "Horsepower":112,
       "Weight_in_lbs":2868,
       "Acceleration":15.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1415,7 +1415,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3399,
       "Acceleration":11,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1426,7 +1426,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2660,
       "Acceleration":14,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Europe"
    },
    {
@@ -1437,7 +1437,7 @@
       "Horsepower":122,
       "Weight_in_lbs":2807,
       "Acceleration":13.5,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"Japan"
    },
    {
@@ -1448,7 +1448,7 @@
       "Horsepower":180,
       "Weight_in_lbs":3664,
       "Acceleration":11,
-      "Year":1973,
+      "Year":"1973-01-01",
       "Origin":"USA"
    },
    {
@@ -1459,7 +1459,7 @@
       "Horsepower":95,
       "Weight_in_lbs":3102,
       "Acceleration":16.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1470,7 +1470,7 @@
       "Horsepower":null,
       "Weight_in_lbs":2875,
       "Acceleration":17,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1481,7 +1481,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2901,
       "Acceleration":16,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1492,7 +1492,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3336,
       "Acceleration":17,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1503,7 +1503,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1950,
       "Acceleration":19,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1514,7 +1514,7 @@
       "Horsepower":80,
       "Weight_in_lbs":2451,
       "Acceleration":16.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1525,7 +1525,7 @@
       "Horsepower":65,
       "Weight_in_lbs":1836,
       "Acceleration":21,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1536,7 +1536,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2542,
       "Acceleration":17,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1547,7 +1547,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3781,
       "Acceleration":17,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1558,7 +1558,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3632,
       "Acceleration":18,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1569,7 +1569,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3613,
       "Acceleration":16.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1580,7 +1580,7 @@
       "Horsepower":140,
       "Weight_in_lbs":4141,
       "Acceleration":14,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1591,7 +1591,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4699,
       "Acceleration":14.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1602,7 +1602,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4457,
       "Acceleration":13.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1613,7 +1613,7 @@
       "Horsepower":140,
       "Weight_in_lbs":4638,
       "Acceleration":16,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1624,7 +1624,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4257,
       "Acceleration":15.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1635,7 +1635,7 @@
       "Horsepower":83,
       "Weight_in_lbs":2219,
       "Acceleration":16.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1646,7 +1646,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1963,
       "Acceleration":15.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1657,7 +1657,7 @@
       "Horsepower":78,
       "Weight_in_lbs":2300,
       "Acceleration":14.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1668,7 +1668,7 @@
       "Horsepower":52,
       "Weight_in_lbs":1649,
       "Acceleration":16.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1679,7 +1679,7 @@
       "Horsepower":61,
       "Weight_in_lbs":2003,
       "Acceleration":19,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1690,7 +1690,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2125,
       "Acceleration":14.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"USA"
    },
    {
@@ -1701,7 +1701,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2108,
       "Acceleration":15.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1712,7 +1712,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2246,
       "Acceleration":14,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1723,7 +1723,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2489,
       "Acceleration":15,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1734,7 +1734,7 @@
       "Horsepower":93,
       "Weight_in_lbs":2391,
       "Acceleration":15.5,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Japan"
    },
    {
@@ -1745,7 +1745,7 @@
       "Horsepower":67,
       "Weight_in_lbs":2000,
       "Acceleration":16,
-      "Year":1974,
+      "Year":"1974-01-01",
       "Origin":"Europe"
    },
    {
@@ -1756,7 +1756,7 @@
       "Horsepower":95,
       "Weight_in_lbs":3264,
       "Acceleration":16,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1767,7 +1767,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3459,
       "Acceleration":16,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1778,7 +1778,7 @@
       "Horsepower":72,
       "Weight_in_lbs":3432,
       "Acceleration":21,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1789,7 +1789,7 @@
       "Horsepower":72,
       "Weight_in_lbs":3158,
       "Acceleration":19.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1800,7 +1800,7 @@
       "Horsepower":170,
       "Weight_in_lbs":4668,
       "Acceleration":11.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1811,7 +1811,7 @@
       "Horsepower":145,
       "Weight_in_lbs":4440,
       "Acceleration":14,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1822,7 +1822,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4498,
       "Acceleration":14.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1833,7 +1833,7 @@
       "Horsepower":148,
       "Weight_in_lbs":4657,
       "Acceleration":13.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1844,7 +1844,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3907,
       "Acceleration":21,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1855,7 +1855,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3897,
       "Acceleration":18.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1866,7 +1866,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3730,
       "Acceleration":19,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1877,7 +1877,7 @@
       "Horsepower":95,
       "Weight_in_lbs":3785,
       "Acceleration":19,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1888,7 +1888,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3039,
       "Acceleration":15,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1899,7 +1899,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3221,
       "Acceleration":13.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1910,7 +1910,7 @@
       "Horsepower":129,
       "Weight_in_lbs":3169,
       "Acceleration":12,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1921,7 +1921,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2171,
       "Acceleration":16,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Japan"
    },
    {
@@ -1932,7 +1932,7 @@
       "Horsepower":83,
       "Weight_in_lbs":2639,
       "Acceleration":17,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1943,7 +1943,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2914,
       "Acceleration":16,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1954,7 +1954,7 @@
       "Horsepower":78,
       "Weight_in_lbs":2592,
       "Acceleration":18.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -1965,7 +1965,7 @@
       "Horsepower":96,
       "Weight_in_lbs":2702,
       "Acceleration":13.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Japan"
    },
    {
@@ -1976,7 +1976,7 @@
       "Horsepower":71,
       "Weight_in_lbs":2223,
       "Acceleration":16.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -1987,7 +1987,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2545,
       "Acceleration":17,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Japan"
    },
    {
@@ -1998,7 +1998,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2984,
       "Acceleration":14.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -2009,7 +2009,7 @@
       "Horsepower":70,
       "Weight_in_lbs":1937,
       "Acceleration":14,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -2020,7 +2020,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3211,
       "Acceleration":17,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"USA"
    },
    {
@@ -2031,7 +2031,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2694,
       "Acceleration":15,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -2042,7 +2042,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2957,
       "Acceleration":17,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -2053,7 +2053,7 @@
       "Horsepower":98,
       "Weight_in_lbs":2945,
       "Acceleration":14.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -2064,7 +2064,7 @@
       "Horsepower":115,
       "Weight_in_lbs":2671,
       "Acceleration":13.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Europe"
    },
    {
@@ -2075,7 +2075,7 @@
       "Horsepower":53,
       "Weight_in_lbs":1795,
       "Acceleration":17.5,
-      "Year":1975,
+      "Year":"1975-01-01",
       "Origin":"Japan"
    },
    {
@@ -2086,7 +2086,7 @@
       "Horsepower":86,
       "Weight_in_lbs":2464,
       "Acceleration":15.5,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2097,7 +2097,7 @@
       "Horsepower":81,
       "Weight_in_lbs":2220,
       "Acceleration":16.9,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2108,7 +2108,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2572,
       "Acceleration":14.9,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2119,7 +2119,7 @@
       "Horsepower":79,
       "Weight_in_lbs":2255,
       "Acceleration":17.7,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2130,7 +2130,7 @@
       "Horsepower":83,
       "Weight_in_lbs":2202,
       "Acceleration":15.3,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2141,7 +2141,7 @@
       "Horsepower":140,
       "Weight_in_lbs":4215,
       "Acceleration":13,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2152,7 +2152,7 @@
       "Horsepower":150,
       "Weight_in_lbs":4190,
       "Acceleration":13,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2163,7 +2163,7 @@
       "Horsepower":120,
       "Weight_in_lbs":3962,
       "Acceleration":13.9,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2174,7 +2174,7 @@
       "Horsepower":152,
       "Weight_in_lbs":4215,
       "Acceleration":12.8,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2185,7 +2185,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3233,
       "Acceleration":15.4,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2196,7 +2196,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3353,
       "Acceleration":14.5,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2207,7 +2207,7 @@
       "Horsepower":81,
       "Weight_in_lbs":3012,
       "Acceleration":17.6,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2218,7 +2218,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3085,
       "Acceleration":17.6,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2229,7 +2229,7 @@
       "Horsepower":52,
       "Weight_in_lbs":2035,
       "Acceleration":22.2,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2240,7 +2240,7 @@
       "Horsepower":60,
       "Weight_in_lbs":2164,
       "Acceleration":22.1,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2251,7 +2251,7 @@
       "Horsepower":70,
       "Weight_in_lbs":1937,
       "Acceleration":14.2,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2262,7 +2262,7 @@
       "Horsepower":53,
       "Weight_in_lbs":1795,
       "Acceleration":17.4,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Japan"
    },
    {
@@ -2273,7 +2273,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3651,
       "Acceleration":17.7,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2284,7 +2284,7 @@
       "Horsepower":78,
       "Weight_in_lbs":3574,
       "Acceleration":21,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2295,7 +2295,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3645,
       "Acceleration":16.2,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2306,7 +2306,7 @@
       "Horsepower":95,
       "Weight_in_lbs":3193,
       "Acceleration":17.8,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2317,7 +2317,7 @@
       "Horsepower":71,
       "Weight_in_lbs":1825,
       "Acceleration":12.2,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2328,7 +2328,7 @@
       "Horsepower":70,
       "Weight_in_lbs":1990,
       "Acceleration":17,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Japan"
    },
    {
@@ -2339,7 +2339,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2155,
       "Acceleration":16.4,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Japan"
    },
    {
@@ -2350,7 +2350,7 @@
       "Horsepower":72,
       "Weight_in_lbs":2565,
       "Acceleration":13.6,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2361,7 +2361,7 @@
       "Horsepower":102,
       "Weight_in_lbs":3150,
       "Acceleration":15.7,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2372,7 +2372,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3940,
       "Acceleration":13.2,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2383,7 +2383,7 @@
       "Horsepower":88,
       "Weight_in_lbs":3270,
       "Acceleration":21.9,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2394,7 +2394,7 @@
       "Horsepower":108,
       "Weight_in_lbs":2930,
       "Acceleration":15.5,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Japan"
    },
    {
@@ -2405,7 +2405,7 @@
       "Horsepower":120,
       "Weight_in_lbs":3820,
       "Acceleration":16.7,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"Europe"
    },
    {
@@ -2416,7 +2416,7 @@
       "Horsepower":180,
       "Weight_in_lbs":4380,
       "Acceleration":12.1,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2427,7 +2427,7 @@
       "Horsepower":145,
       "Weight_in_lbs":4055,
       "Acceleration":12,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2438,7 +2438,7 @@
       "Horsepower":130,
       "Weight_in_lbs":3870,
       "Acceleration":15,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2449,7 +2449,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3755,
       "Acceleration":14,
-      "Year":1976,
+      "Year":"1976-01-01",
       "Origin":"USA"
    },
    {
@@ -2460,7 +2460,7 @@
       "Horsepower":68,
       "Weight_in_lbs":2045,
       "Acceleration":18.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2471,7 +2471,7 @@
       "Horsepower":80,
       "Weight_in_lbs":2155,
       "Acceleration":14.8,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2482,7 +2482,7 @@
       "Horsepower":58,
       "Weight_in_lbs":1825,
       "Acceleration":18.6,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Europe"
    },
    {
@@ -2493,7 +2493,7 @@
       "Horsepower":96,
       "Weight_in_lbs":2300,
       "Acceleration":15.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2504,7 +2504,7 @@
       "Horsepower":70,
       "Weight_in_lbs":1945,
       "Acceleration":16.8,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2515,7 +2515,7 @@
       "Horsepower":145,
       "Weight_in_lbs":3880,
       "Acceleration":12.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2526,7 +2526,7 @@
       "Horsepower":110,
       "Weight_in_lbs":4060,
       "Acceleration":19,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2537,7 +2537,7 @@
       "Horsepower":145,
       "Weight_in_lbs":4140,
       "Acceleration":13.7,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2548,7 +2548,7 @@
       "Horsepower":130,
       "Weight_in_lbs":4295,
       "Acceleration":14.9,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2559,7 +2559,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3520,
       "Acceleration":16.4,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2570,7 +2570,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3425,
       "Acceleration":16.9,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2581,7 +2581,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3630,
       "Acceleration":17.7,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2592,7 +2592,7 @@
       "Horsepower":98,
       "Weight_in_lbs":3525,
       "Acceleration":19,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2603,7 +2603,7 @@
       "Horsepower":180,
       "Weight_in_lbs":4220,
       "Acceleration":11.1,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2614,7 +2614,7 @@
       "Horsepower":170,
       "Weight_in_lbs":4165,
       "Acceleration":11.4,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2625,7 +2625,7 @@
       "Horsepower":190,
       "Weight_in_lbs":4325,
       "Acceleration":12.2,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2636,7 +2636,7 @@
       "Horsepower":149,
       "Weight_in_lbs":4335,
       "Acceleration":14.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2647,7 +2647,7 @@
       "Horsepower":78,
       "Weight_in_lbs":1940,
       "Acceleration":14.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Europe"
    },
    {
@@ -2658,7 +2658,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2740,
       "Acceleration":16,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2669,7 +2669,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2265,
       "Acceleration":18.2,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2680,7 +2680,7 @@
       "Horsepower":89,
       "Weight_in_lbs":2755,
       "Acceleration":15.8,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2691,7 +2691,7 @@
       "Horsepower":63,
       "Weight_in_lbs":2051,
       "Acceleration":17,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2702,7 +2702,7 @@
       "Horsepower":83,
       "Weight_in_lbs":2075,
       "Acceleration":15.9,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"USA"
    },
    {
@@ -2713,7 +2713,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1985,
       "Acceleration":16.4,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2724,7 +2724,7 @@
       "Horsepower":78,
       "Weight_in_lbs":2190,
       "Acceleration":14.1,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Europe"
    },
    {
@@ -2735,7 +2735,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2815,
       "Acceleration":14.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2746,7 +2746,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2600,
       "Acceleration":12.8,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Europe"
    },
    {
@@ -2757,7 +2757,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2720,
       "Acceleration":13.5,
-      "Year":1977,
+      "Year":"1977-01-01",
       "Origin":"Japan"
    },
    {
@@ -2768,7 +2768,7 @@
       "Horsepower":48,
       "Weight_in_lbs":1985,
       "Acceleration":21.5,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -2779,7 +2779,7 @@
       "Horsepower":66,
       "Weight_in_lbs":1800,
       "Acceleration":14.4,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2790,7 +2790,7 @@
       "Horsepower":52,
       "Weight_in_lbs":1985,
       "Acceleration":19.4,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -2801,7 +2801,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2070,
       "Acceleration":18.6,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -2812,7 +2812,7 @@
       "Horsepower":60,
       "Weight_in_lbs":1800,
       "Acceleration":16.4,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -2823,7 +2823,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3365,
       "Acceleration":15.5,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2834,7 +2834,7 @@
       "Horsepower":140,
       "Weight_in_lbs":3735,
       "Acceleration":13.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2845,7 +2845,7 @@
       "Horsepower":139,
       "Weight_in_lbs":3570,
       "Acceleration":12.8,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2856,7 +2856,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3535,
       "Acceleration":19.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2867,7 +2867,7 @@
       "Horsepower":95,
       "Weight_in_lbs":3155,
       "Acceleration":18.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2878,7 +2878,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2965,
       "Acceleration":15.8,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2889,7 +2889,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2720,
       "Acceleration":15.4,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2900,7 +2900,7 @@
       "Horsepower":100,
       "Weight_in_lbs":3430,
       "Acceleration":17.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2911,7 +2911,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3210,
       "Acceleration":17.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2922,7 +2922,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3380,
       "Acceleration":15.8,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2933,7 +2933,7 @@
       "Horsepower":85,
       "Weight_in_lbs":3070,
       "Acceleration":16.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2944,7 +2944,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3620,
       "Acceleration":18.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2955,7 +2955,7 @@
       "Horsepower":120,
       "Weight_in_lbs":3410,
       "Acceleration":15.1,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2966,7 +2966,7 @@
       "Horsepower":145,
       "Weight_in_lbs":3425,
       "Acceleration":13.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2977,7 +2977,7 @@
       "Horsepower":165,
       "Weight_in_lbs":3445,
       "Acceleration":13.4,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2988,7 +2988,7 @@
       "Horsepower":139,
       "Weight_in_lbs":3205,
       "Acceleration":11.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -2999,7 +2999,7 @@
       "Horsepower":140,
       "Weight_in_lbs":4080,
       "Acceleration":13.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -3010,7 +3010,7 @@
       "Horsepower":68,
       "Weight_in_lbs":2155,
       "Acceleration":16.5,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -3021,7 +3021,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2560,
       "Acceleration":14.2,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -3032,7 +3032,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2300,
       "Acceleration":14.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -3043,7 +3043,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2230,
       "Acceleration":14.5,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -3054,7 +3054,7 @@
       "Horsepower":95,
       "Weight_in_lbs":2515,
       "Acceleration":14.8,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -3065,7 +3065,7 @@
       "Horsepower":105,
       "Weight_in_lbs":2745,
       "Acceleration":16.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -3076,7 +3076,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2855,
       "Acceleration":17.6,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"USA"
    },
    {
@@ -3087,7 +3087,7 @@
       "Horsepower":97,
       "Weight_in_lbs":2405,
       "Acceleration":14.9,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -3098,7 +3098,7 @@
       "Horsepower":103,
       "Weight_in_lbs":2830,
       "Acceleration":15.9,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -3109,7 +3109,7 @@
       "Horsepower":125,
       "Weight_in_lbs":3140,
       "Acceleration":13.6,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -3120,7 +3120,7 @@
       "Horsepower":115,
       "Weight_in_lbs":2795,
       "Acceleration":15.7,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -3131,7 +3131,7 @@
       "Horsepower":133,
       "Weight_in_lbs":3410,
       "Acceleration":15.8,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -3142,7 +3142,7 @@
       "Horsepower":71,
       "Weight_in_lbs":1990,
       "Acceleration":14.9,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Europe"
    },
    {
@@ -3153,7 +3153,7 @@
       "Horsepower":68,
       "Weight_in_lbs":2135,
       "Acceleration":16.6,
-      "Year":1978,
+      "Year":"1978-01-01",
       "Origin":"Japan"
    },
    {
@@ -3164,7 +3164,7 @@
       "Horsepower":115,
       "Weight_in_lbs":3245,
       "Acceleration":15.4,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3175,7 +3175,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2990,
       "Acceleration":18.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3186,7 +3186,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2890,
       "Acceleration":17.3,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3197,7 +3197,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3265,
       "Acceleration":18.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3208,7 +3208,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3360,
       "Acceleration":16.6,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3219,7 +3219,7 @@
       "Horsepower":130,
       "Weight_in_lbs":3840,
       "Acceleration":15.4,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3230,7 +3230,7 @@
       "Horsepower":129,
       "Weight_in_lbs":3725,
       "Acceleration":13.4,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3241,7 +3241,7 @@
       "Horsepower":138,
       "Weight_in_lbs":3955,
       "Acceleration":13.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3252,7 +3252,7 @@
       "Horsepower":135,
       "Weight_in_lbs":3830,
       "Acceleration":15.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3263,7 +3263,7 @@
       "Horsepower":155,
       "Weight_in_lbs":4360,
       "Acceleration":14.9,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3274,7 +3274,7 @@
       "Horsepower":142,
       "Weight_in_lbs":4054,
       "Acceleration":14.3,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3285,7 +3285,7 @@
       "Horsepower":125,
       "Weight_in_lbs":3605,
       "Acceleration":15,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3296,7 +3296,7 @@
       "Horsepower":150,
       "Weight_in_lbs":3940,
       "Acceleration":13,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3307,7 +3307,7 @@
       "Horsepower":71,
       "Weight_in_lbs":1925,
       "Acceleration":14,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Europe"
    },
    {
@@ -3318,7 +3318,7 @@
       "Horsepower":65,
       "Weight_in_lbs":1975,
       "Acceleration":15.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Japan"
    },
    {
@@ -3329,7 +3329,7 @@
       "Horsepower":80,
       "Weight_in_lbs":1915,
       "Acceleration":14.4,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3340,7 +3340,7 @@
       "Horsepower":80,
       "Weight_in_lbs":2670,
       "Acceleration":15,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3351,7 +3351,7 @@
       "Horsepower":77,
       "Weight_in_lbs":3530,
       "Acceleration":20.1,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Europe"
    },
    {
@@ -3362,7 +3362,7 @@
       "Horsepower":125,
       "Weight_in_lbs":3900,
       "Acceleration":17.4,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3373,7 +3373,7 @@
       "Horsepower":71,
       "Weight_in_lbs":3190,
       "Acceleration":24.8,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Europe"
    },
    {
@@ -3384,7 +3384,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3420,
       "Acceleration":22.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3395,7 +3395,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2200,
       "Acceleration":13.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3406,7 +3406,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2150,
       "Acceleration":14.9,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3417,7 +3417,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2020,
       "Acceleration":19.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Japan"
    },
    {
@@ -3428,7 +3428,7 @@
       "Horsepower":69,
       "Weight_in_lbs":2130,
       "Acceleration":14.7,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"Europe"
    },
    {
@@ -3439,7 +3439,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2670,
       "Acceleration":16,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3450,7 +3450,7 @@
       "Horsepower":115,
       "Weight_in_lbs":2595,
       "Acceleration":11.3,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3461,7 +3461,7 @@
       "Horsepower":115,
       "Weight_in_lbs":2700,
       "Acceleration":12.9,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3472,7 +3472,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2556,
       "Acceleration":13.2,
-      "Year":1979,
+      "Year":"1979-01-01",
       "Origin":"USA"
    },
    {
@@ -3483,7 +3483,7 @@
       "Horsepower":76,
       "Weight_in_lbs":2144,
       "Acceleration":14.7,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3494,7 +3494,7 @@
       "Horsepower":60,
       "Weight_in_lbs":1968,
       "Acceleration":18.8,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3505,7 +3505,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2120,
       "Acceleration":15.5,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3516,7 +3516,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2019,
       "Acceleration":16.4,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3527,7 +3527,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2678,
       "Acceleration":16.5,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3538,7 +3538,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2870,
       "Acceleration":18.1,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3549,7 +3549,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3003,
       "Acceleration":20.1,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3560,7 +3560,7 @@
       "Horsepower":90,
       "Weight_in_lbs":3381,
       "Acceleration":18.7,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3571,7 +3571,7 @@
       "Horsepower":78,
       "Weight_in_lbs":2188,
       "Acceleration":15.8,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3582,7 +3582,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2711,
       "Acceleration":15.5,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3593,7 +3593,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2542,
       "Acceleration":17.5,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3604,7 +3604,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2434,
       "Acceleration":15,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3615,7 +3615,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2265,
       "Acceleration":15.2,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3626,7 +3626,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2110,
       "Acceleration":17.9,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3637,7 +3637,7 @@
       "Horsepower":105,
       "Weight_in_lbs":2800,
       "Acceleration":14.4,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3648,7 +3648,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2110,
       "Acceleration":19.2,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3659,7 +3659,7 @@
       "Horsepower":48,
       "Weight_in_lbs":2085,
       "Acceleration":21.7,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3670,7 +3670,7 @@
       "Horsepower":48,
       "Weight_in_lbs":2335,
       "Acceleration":23.7,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3681,7 +3681,7 @@
       "Horsepower":67,
       "Weight_in_lbs":2950,
       "Acceleration":19.9,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3692,7 +3692,7 @@
       "Horsepower":67,
       "Weight_in_lbs":3250,
       "Acceleration":21.8,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3703,7 +3703,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1850,
       "Acceleration":13.8,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3714,7 +3714,7 @@
       "Horsepower":null,
       "Weight_in_lbs":1835,
       "Acceleration":17.3,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3725,7 +3725,7 @@
       "Horsepower":67,
       "Weight_in_lbs":2145,
       "Acceleration":18,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3736,7 +3736,7 @@
       "Horsepower":62,
       "Weight_in_lbs":1845,
       "Acceleration":15.3,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3747,7 +3747,7 @@
       "Horsepower":132,
       "Weight_in_lbs":2910,
       "Acceleration":11.4,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3758,7 +3758,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2420,
       "Acceleration":12.5,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3769,7 +3769,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2500,
       "Acceleration":15.1,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Europe"
    },
    {
@@ -3780,7 +3780,7 @@
       "Horsepower":null,
       "Weight_in_lbs":2905,
       "Acceleration":14.3,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"USA"
    },
    {
@@ -3791,7 +3791,7 @@
       "Horsepower":72,
       "Weight_in_lbs":2290,
       "Acceleration":17,
-      "Year":1980,
+      "Year":"1980-01-01",
       "Origin":"Japan"
    },
    {
@@ -3802,7 +3802,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2490,
       "Acceleration":15.7,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3813,7 +3813,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2635,
       "Acceleration":16.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3824,7 +3824,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2620,
       "Acceleration":14.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3835,7 +3835,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2725,
       "Acceleration":12.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3846,7 +3846,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2385,
       "Acceleration":12.9,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3857,7 +3857,7 @@
       "Horsepower":58,
       "Weight_in_lbs":1755,
       "Acceleration":16.9,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3868,7 +3868,7 @@
       "Horsepower":64,
       "Weight_in_lbs":1875,
       "Acceleration":16.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3879,7 +3879,7 @@
       "Horsepower":60,
       "Weight_in_lbs":1760,
       "Acceleration":16.1,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3890,7 +3890,7 @@
       "Horsepower":67,
       "Weight_in_lbs":2065,
       "Acceleration":17.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3901,7 +3901,7 @@
       "Horsepower":65,
       "Weight_in_lbs":1975,
       "Acceleration":19.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3912,7 +3912,7 @@
       "Horsepower":62,
       "Weight_in_lbs":2050,
       "Acceleration":17.3,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3923,7 +3923,7 @@
       "Horsepower":68,
       "Weight_in_lbs":1985,
       "Acceleration":16,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -3934,7 +3934,7 @@
       "Horsepower":63,
       "Weight_in_lbs":2215,
       "Acceleration":14.9,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3945,7 +3945,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2045,
       "Acceleration":16.2,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3956,7 +3956,7 @@
       "Horsepower":65,
       "Weight_in_lbs":2380,
       "Acceleration":20.7,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -3967,7 +3967,7 @@
       "Horsepower":74,
       "Weight_in_lbs":2190,
       "Acceleration":14.2,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -3978,7 +3978,7 @@
       "Horsepower":null,
       "Weight_in_lbs":2320,
       "Acceleration":15.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -3989,7 +3989,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2210,
       "Acceleration":14.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4000,7 +4000,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2350,
       "Acceleration":16.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4011,7 +4011,7 @@
       "Horsepower":100,
       "Weight_in_lbs":2615,
       "Acceleration":14.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4022,7 +4022,7 @@
       "Horsepower":74,
       "Weight_in_lbs":2635,
       "Acceleration":18.3,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4033,7 +4033,7 @@
       "Horsepower":80,
       "Weight_in_lbs":3230,
       "Acceleration":20.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -4044,7 +4044,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2800,
       "Acceleration":15.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -4055,7 +4055,7 @@
       "Horsepower":76,
       "Weight_in_lbs":3160,
       "Acceleration":19.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -4066,7 +4066,7 @@
       "Horsepower":116,
       "Weight_in_lbs":2900,
       "Acceleration":12.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4077,7 +4077,7 @@
       "Horsepower":120,
       "Weight_in_lbs":2930,
       "Acceleration":13.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4088,7 +4088,7 @@
       "Horsepower":110,
       "Weight_in_lbs":3415,
       "Acceleration":15.8,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4099,7 +4099,7 @@
       "Horsepower":105,
       "Weight_in_lbs":3725,
       "Acceleration":19,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4110,7 +4110,7 @@
       "Horsepower":88,
       "Weight_in_lbs":3060,
       "Acceleration":17.1,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4121,7 +4121,7 @@
       "Horsepower":85,
       "Weight_in_lbs":3465,
       "Acceleration":16.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4132,7 +4132,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2605,
       "Acceleration":19.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4143,7 +4143,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2640,
       "Acceleration":18.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4154,7 +4154,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2395,
       "Acceleration":18,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4165,7 +4165,7 @@
       "Horsepower":85,
       "Weight_in_lbs":2575,
       "Acceleration":16.2,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4176,7 +4176,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2525,
       "Acceleration":16,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4187,7 +4187,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2735,
       "Acceleration":18,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4198,7 +4198,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2865,
       "Acceleration":16.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4209,7 +4209,7 @@
       "Horsepower":null,
       "Weight_in_lbs":3035,
       "Acceleration":20.5,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4220,7 +4220,7 @@
       "Horsepower":74,
       "Weight_in_lbs":1980,
       "Acceleration":15.3,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -4231,7 +4231,7 @@
       "Horsepower":68,
       "Weight_in_lbs":2025,
       "Acceleration":18.2,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4242,7 +4242,7 @@
       "Horsepower":68,
       "Weight_in_lbs":1970,
       "Acceleration":17.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4253,7 +4253,7 @@
       "Horsepower":63,
       "Weight_in_lbs":2125,
       "Acceleration":14.7,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4264,7 +4264,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2125,
       "Acceleration":17.3,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4275,7 +4275,7 @@
       "Horsepower":88,
       "Weight_in_lbs":2160,
       "Acceleration":14.5,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4286,7 +4286,7 @@
       "Horsepower":75,
       "Weight_in_lbs":2205,
       "Acceleration":14.5,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4297,7 +4297,7 @@
       "Horsepower":70,
       "Weight_in_lbs":2245,
       "Acceleration":16.9,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4308,7 +4308,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1965,
       "Acceleration":15,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4319,7 +4319,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1965,
       "Acceleration":15.7,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4330,7 +4330,7 @@
       "Horsepower":67,
       "Weight_in_lbs":1995,
       "Acceleration":16.2,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4341,7 +4341,7 @@
       "Horsepower":110,
       "Weight_in_lbs":2945,
       "Acceleration":16.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4352,7 +4352,7 @@
       "Horsepower":85,
       "Weight_in_lbs":3015,
       "Acceleration":17,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4363,7 +4363,7 @@
       "Horsepower":92,
       "Weight_in_lbs":2585,
       "Acceleration":14.5,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4374,7 +4374,7 @@
       "Horsepower":112,
       "Weight_in_lbs":2835,
       "Acceleration":14.7,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4385,7 +4385,7 @@
       "Horsepower":96,
       "Weight_in_lbs":2665,
       "Acceleration":13.9,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Japan"
    },
    {
@@ -4396,7 +4396,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2370,
       "Acceleration":13,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4407,7 +4407,7 @@
       "Horsepower":90,
       "Weight_in_lbs":2950,
       "Acceleration":17.3,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4418,7 +4418,7 @@
       "Horsepower":86,
       "Weight_in_lbs":2790,
       "Acceleration":15.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4429,7 +4429,7 @@
       "Horsepower":52,
       "Weight_in_lbs":2130,
       "Acceleration":24.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"Europe"
    },
    {
@@ -4440,7 +4440,7 @@
       "Horsepower":84,
       "Weight_in_lbs":2295,
       "Acceleration":11.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4451,7 +4451,7 @@
       "Horsepower":79,
       "Weight_in_lbs":2625,
       "Acceleration":18.6,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    },
    {
@@ -4462,7 +4462,7 @@
       "Horsepower":82,
       "Weight_in_lbs":2720,
       "Acceleration":19.4,
-      "Year":1982,
+      "Year":"1982-01-01",
       "Origin":"USA"
    }
 ]


### PR DESCRIPTION
Replaces dates of the format `YYYY` with dates of the format `YYYY-01-01` since the former is not supported.