### PR TITLE
Add stacked area example

### DIFF
--- a/data/iowa-electricity.csv
+++ b/data/iowa-electricity.csv
@@ -1,4 +1,4 @@
-year,type,net_generation
+year,source,net_generation
 2001,Fossil Fuels,35361
 2002,Fossil Fuels,35991
 2003,Fossil Fuels,36234

--- a/data/iowa-electricity.csv
+++ b/data/iowa-electricity.csv
@@ -1,52 +1,52 @@
-date,year,source,net_generation
-2001-01-01,2001,Fossil Fuels,35361
-2002-01-01,2002,Fossil Fuels,35991
-2003-01-01,2003,Fossil Fuels,36234
-2004-01-01,2004,Fossil Fuels,36205
-2005-01-01,2005,Fossil Fuels,36883
-2006-01-01,2006,Fossil Fuels,37014
-2007-01-01,2007,Fossil Fuels,41389
-2008-01-01,2008,Fossil Fuels,42734
-2009-01-01,2009,Fossil Fuels,38620
-2010-01-01,2010,Fossil Fuels,42750
-2011-01-01,2011,Fossil Fuels,39361
-2012-01-01,2012,Fossil Fuels,37379
-2013-01-01,2013,Fossil Fuels,34873
-2014-01-01,2014,Fossil Fuels,35250
-2015-01-01,2015,Fossil Fuels,32319
-2016-01-01,2016,Fossil Fuels,28437
-2017-01-01,2017,Fossil Fuels,29329
-2001-01-01,2001,Nuclear Energy,3853
-2002-01-01,2002,Nuclear Energy,4574
-2003-01-01,2003,Nuclear Energy,3988
-2004-01-01,2004,Nuclear Energy,4929
-2005-01-01,2005,Nuclear Energy,4538
-2006-01-01,2006,Nuclear Energy,5095
-2007-01-01,2007,Nuclear Energy,4519
-2008-01-01,2008,Nuclear Energy,5282
-2009-01-01,2009,Nuclear Energy,4679
-2010-01-01,2010,Nuclear Energy,4451
-2011-01-01,2011,Nuclear Energy,5215
-2012-01-01,2012,Nuclear Energy,4347
-2013-01-01,2013,Nuclear Energy,5321
-2014-01-01,2014,Nuclear Energy,4152
-2015-01-01,2015,Nuclear Energy,5243
-2016-01-01,2016,Nuclear Energy,4703
-2017-01-01,2017,Nuclear Energy,5214
-2001-01-01,2001,Renewables,1437
-2002-01-01,2002,Renewables,1963
-2003-01-01,2003,Renewables,1885
-2004-01-01,2004,Renewables,2102
-2005-01-01,2005,Renewables,2724
-2006-01-01,2006,Renewables,3364
-2007-01-01,2007,Renewables,3870
-2008-01-01,2008,Renewables,5070
-2009-01-01,2009,Renewables,8560
-2010-01-01,2010,Renewables,10308
-2011-01-01,2011,Renewables,11795
-2012-01-01,2012,Renewables,14949
-2013-01-01,2013,Renewables,16476
-2014-01-01,2014,Renewables,17452
-2015-01-01,2015,Renewables,19091
-2016-01-01,2016,Renewables,21241
-2017-01-01,2017,Renewables,21933
+year,source,net_generation
+2001-01-01,Fossil Fuels,35361
+2002-01-01,Fossil Fuels,35991
+2003-01-01,Fossil Fuels,36234
+2004-01-01,Fossil Fuels,36205
+2005-01-01,Fossil Fuels,36883
+2006-01-01,Fossil Fuels,37014
+2007-01-01,Fossil Fuels,41389
+2008-01-01,Fossil Fuels,42734
+2009-01-01,Fossil Fuels,38620
+2010-01-01,Fossil Fuels,42750
+2011-01-01,Fossil Fuels,39361
+2012-01-01,Fossil Fuels,37379
+2013-01-01,Fossil Fuels,34873
+2014-01-01,Fossil Fuels,35250
+2015-01-01,Fossil Fuels,32319
+2016-01-01,Fossil Fuels,28437
+2017-01-01,Fossil Fuels,29329
+2001-01-01,Nuclear Energy,3853
+2002-01-01,Nuclear Energy,4574
+2003-01-01,Nuclear Energy,3988
+2004-01-01,Nuclear Energy,4929
+2005-01-01,Nuclear Energy,4538
+2006-01-01,Nuclear Energy,5095
+2007-01-01,Nuclear Energy,4519
+2008-01-01,Nuclear Energy,5282
+2009-01-01,Nuclear Energy,4679
+2010-01-01,Nuclear Energy,4451
+2011-01-01,Nuclear Energy,5215
+2012-01-01,Nuclear Energy,4347
+2013-01-01,Nuclear Energy,5321
+2014-01-01,Nuclear Energy,4152
+2015-01-01,Nuclear Energy,5243
+2016-01-01,Nuclear Energy,4703
+2017-01-01,Nuclear Energy,5214
+2001-01-01,Renewables,1437
+2002-01-01,Renewables,1963
+2003-01-01,Renewables,1885
+2004-01-01,Renewables,2102
+2005-01-01,Renewables,2724
+2006-01-01,Renewables,3364
+2007-01-01,Renewables,3870
+2008-01-01,Renewables,5070
+2009-01-01,Renewables,8560
+2010-01-01,Renewables,10308
+2011-01-01,Renewables,11795
+2012-01-01,Renewables,14949
+2013-01-01,Renewables,16476
+2014-01-01,Renewables,17452
+2015-01-01,Renewables,19091
+2016-01-01,Renewables,21241
+2017-01-01,Renewables,21933

--- a/data/iowa-electricity.csv
+++ b/data/iowa-electricity.csv
@@ -1,0 +1,52 @@
+year,type,net_generation
+2001,Fossil Fuels,35361
+2002,Fossil Fuels,35991
+2003,Fossil Fuels,36234
+2004,Fossil Fuels,36205
+2005,Fossil Fuels,36883
+2006,Fossil Fuels,37014
+2007,Fossil Fuels,41389
+2008,Fossil Fuels,42734
+2009,Fossil Fuels,38620
+2010,Fossil Fuels,42750
+2011,Fossil Fuels,39361
+2012,Fossil Fuels,37379
+2013,Fossil Fuels,34873
+2014,Fossil Fuels,35250
+2015,Fossil Fuels,32319
+2016,Fossil Fuels,28437
+2017,Fossil Fuels,29329
+2001,Nuclear Energy,3853
+2002,Nuclear Energy,4574
+2003,Nuclear Energy,3988
+2004,Nuclear Energy,4929
+2005,Nuclear Energy,4538
+2006,Nuclear Energy,5095
+2007,Nuclear Energy,4519
+2008,Nuclear Energy,5282
+2009,Nuclear Energy,4679
+2010,Nuclear Energy,4451
+2011,Nuclear Energy,5215
+2012,Nuclear Energy,4347
+2013,Nuclear Energy,5321
+2014,Nuclear Energy,4152
+2015,Nuclear Energy,5243
+2016,Nuclear Energy,4703
+2017,Nuclear Energy,5214
+2001,Renewables,1437
+2002,Renewables,1963
+2003,Renewables,1885
+2004,Renewables,2102
+2005,Renewables,2724
+2006,Renewables,3364
+2007,Renewables,3870
+2008,Renewables,5070
+2009,Renewables,8560
+2010,Renewables,10308
+2011,Renewables,11795
+2012,Renewables,14949
+2013,Renewables,16476
+2014,Renewables,17452
+2015,Renewables,19091
+2016,Renewables,21241
+2017,Renewables,21933

--- a/data/iowa-electricity.csv
+++ b/data/iowa-electricity.csv
@@ -1,52 +1,52 @@
-year,source,net_generation
-2001,Fossil Fuels,35361
-2002,Fossil Fuels,35991
-2003,Fossil Fuels,36234
-2004,Fossil Fuels,36205
-2005,Fossil Fuels,36883
-2006,Fossil Fuels,37014
-2007,Fossil Fuels,41389
-2008,Fossil Fuels,42734
-2009,Fossil Fuels,38620
-2010,Fossil Fuels,42750
-2011,Fossil Fuels,39361
-2012,Fossil Fuels,37379
-2013,Fossil Fuels,34873
-2014,Fossil Fuels,35250
-2015,Fossil Fuels,32319
-2016,Fossil Fuels,28437
-2017,Fossil Fuels,29329
-2001,Nuclear Energy,3853
-2002,Nuclear Energy,4574
-2003,Nuclear Energy,3988
-2004,Nuclear Energy,4929
-2005,Nuclear Energy,4538
-2006,Nuclear Energy,5095
-2007,Nuclear Energy,4519
-2008,Nuclear Energy,5282
-2009,Nuclear Energy,4679
-2010,Nuclear Energy,4451
-2011,Nuclear Energy,5215
-2012,Nuclear Energy,4347
-2013,Nuclear Energy,5321
-2014,Nuclear Energy,4152
-2015,Nuclear Energy,5243
-2016,Nuclear Energy,4703
-2017,Nuclear Energy,5214
-2001,Renewables,1437
-2002,Renewables,1963
-2003,Renewables,1885
-2004,Renewables,2102
-2005,Renewables,2724
-2006,Renewables,3364
-2007,Renewables,3870
-2008,Renewables,5070
-2009,Renewables,8560
-2010,Renewables,10308
-2011,Renewables,11795
-2012,Renewables,14949
-2013,Renewables,16476
-2014,Renewables,17452
-2015,Renewables,19091
-2016,Renewables,21241
-2017,Renewables,21933
+date,year,source,net_generation
+2001-01-01,2001,Fossil Fuels,35361
+2002-01-01,2002,Fossil Fuels,35991
+2003-01-01,2003,Fossil Fuels,36234
+2004-01-01,2004,Fossil Fuels,36205
+2005-01-01,2005,Fossil Fuels,36883
+2006-01-01,2006,Fossil Fuels,37014
+2007-01-01,2007,Fossil Fuels,41389
+2008-01-01,2008,Fossil Fuels,42734
+2009-01-01,2009,Fossil Fuels,38620
+2010-01-01,2010,Fossil Fuels,42750
+2011-01-01,2011,Fossil Fuels,39361
+2012-01-01,2012,Fossil Fuels,37379
+2013-01-01,2013,Fossil Fuels,34873
+2014-01-01,2014,Fossil Fuels,35250
+2015-01-01,2015,Fossil Fuels,32319
+2016-01-01,2016,Fossil Fuels,28437
+2017-01-01,2017,Fossil Fuels,29329
+2001-01-01,2001,Nuclear Energy,3853
+2002-01-01,2002,Nuclear Energy,4574
+2003-01-01,2003,Nuclear Energy,3988
+2004-01-01,2004,Nuclear Energy,4929
+2005-01-01,2005,Nuclear Energy,4538
+2006-01-01,2006,Nuclear Energy,5095
+2007-01-01,2007,Nuclear Energy,4519
+2008-01-01,2008,Nuclear Energy,5282
+2009-01-01,2009,Nuclear Energy,4679
+2010-01-01,2010,Nuclear Energy,4451
+2011-01-01,2011,Nuclear Energy,5215
+2012-01-01,2012,Nuclear Energy,4347
+2013-01-01,2013,Nuclear Energy,5321
+2014-01-01,2014,Nuclear Energy,4152
+2015-01-01,2015,Nuclear Energy,5243
+2016-01-01,2016,Nuclear Energy,4703
+2017-01-01,2017,Nuclear Energy,5214
+2001-01-01,2001,Renewables,1437
+2002-01-01,2002,Renewables,1963
+2003-01-01,2003,Renewables,1885
+2004-01-01,2004,Renewables,2102
+2005-01-01,2005,Renewables,2724
+2006-01-01,2006,Renewables,3364
+2007-01-01,2007,Renewables,3870
+2008-01-01,2008,Renewables,5070
+2009-01-01,2009,Renewables,8560
+2010-01-01,2010,Renewables,10308
+2011-01-01,2011,Renewables,11795
+2012-01-01,2012,Renewables,14949
+2013-01-01,2013,Renewables,16476
+2014-01-01,2014,Renewables,17452
+2015-01-01,2015,Renewables,19091
+2016-01-01,2016,Renewables,21241
+2017-01-01,2017,Renewables,21933

--- a/sources.md
+++ b/sources.md
@@ -76,7 +76,7 @@ Generated using the `-graticule` console option of http://mapshaper.org
 
 # iowa-electricity.csv
 
-The state of Iowa has dramatically increased its production of wind power. This file contains the annual net generation of electricity in the state by source in thousand megawatthours. It was compiled by the [U.S. Energy Information Administration](https://www.nytimes.com/2017/06/06/climate/renewable-energy-push-is-strongest-in-the-reddest-states.html) and downloaded on May 6, 2018.
+The state of Iowa has dramatically increased its production of renewable wind power in recent years. This file contains the annual net generation of electricity in the state by source in thousand megawatthours. The dataset was compiled by the [U.S. Energy Information Administration](https://www.eia.gov/beta/electricity/data/browser/#/topic/0?agg=2,0,1&fuel=vvg&geo=00000g&sec=g&linechart=ELEC.GEN.OTH-IA-99.A~ELEC.GEN.COW-IA-99.A~ELEC.GEN.PEL-IA-99.A~ELEC.GEN.PC-IA-99.A~ELEC.GEN.NG-IA-99.A~~ELEC.GEN.NUC-IA-99.A~ELEC.GEN.HYC-IA-99.A~ELEC.GEN.AOR-IA-99.A~ELEC.GEN.HPS-IA-99.A~&columnchart=ELEC.GEN.ALL-IA-99.A&map=ELEC.GEN.ALL-IA-99.A&freq=A&start=2001&end=2017&ctype=linechart&ltype=pin&tab=overview&maptype=0&rse=0&pin=) and downloaded on May 6, 2018. It is useful for illustrating stacked area charts.
 
 
 ## `iris.json`

--- a/sources.md
+++ b/sources.md
@@ -73,6 +73,12 @@ Data about engineers from https://www.bls.gov/oes/tables.htm. Hurricane data fro
 
 Generated using the `-graticule` console option of http://mapshaper.org
 
+
+# iowa-electricity.csv
+
+The state of Iowa has dramatically increased its production of wind power. This file contains the annual net generation of electricity in the state by source in thousand megawatthours. It was compiled by the [U.S. Energy Information Administration](https://www.nytimes.com/2017/06/06/climate/renewable-energy-push-is-strongest-in-the-reddest-states.html) and downloaded on May 6, 2018.
+
+
 ## `iris.json`
 
 ## `jobs.json`


### PR DESCRIPTION
During a discussion in [Altair issue #817](https://github.com/altair-viz/altair/pull/817), our group came to the conclusion that the existing dataset for illustrating stacked area charts, [unemployment across industries](https://vega.github.io/vega-lite/examples/stacked_area_normalize.html), is less than ideal.

Its large number of categories yield a noisy chart. And the mix of values don't change enough over time to make for an interesting normalized chart. See for yourself:

![screenshot from 2018-05-06 22-02-58](https://user-images.githubusercontent.com/9993/39685714-48c809b8-5179-11e8-8023-108bb2202cfc.png)

To try to provide a stronger example to users, we developed a checklist for selecting a better dataset. We settled on:

- Require no data transformations 
- A time series 
- A small number of categories
- Values are percentages of a whole
- Tell an obvious, interesting visual "story."

After some back and forth, we settled on the attached dataset, which I propose for inclusion in this library to serve as its example for stacked area charts. 

The state of Iowa has dramatically increased its production of renewable wind power in recent years. This file contains the annual net generation of electricity in the state by source in thousand megawatthours. The dataset was compiled by the [U.S. Energy Information Administration](https://www.eia.gov/beta/electricity/data/browser/#/topic/0?agg=2,0,1&fuel=vvg&geo=00000g&sec=g&linechart=ELEC.GEN.OTH-IA-99.A~ELEC.GEN.COW-IA-99.A~ELEC.GEN.PEL-IA-99.A~ELEC.GEN.PC-IA-99.A~ELEC.GEN.NG-IA-99.A~~ELEC.GEN.NUC-IA-99.A~ELEC.GEN.HYC-IA-99.A~ELEC.GEN.AOR-IA-99.A~ELEC.GEN.HPS-IA-99.A~&columnchart=ELEC.GEN.ALL-IA-99.A&map=ELEC.GEN.ALL-IA-99.A&freq=A&start=2001&end=2017&ctype=linechart&ltype=pin&tab=overview&maptype=0&rse=0&pin=).

Here's what it looks like in Altair with very little configuration necessary.

```python
import pandas as pd
import altair as alt

data = pd.read_csv("https://gist.githubusercontent.com/palewire/6a8c512c518b98f85358242684584a81/raw/22ee97dba4a59a4cac8c02c70c68ecfbce50aba9/iowa.csv")
alt.Chart(data).mark_area().encode(
    x="year:O",
    y="net_generation:Q",
    color="source:N"
)
```
![](https://user-images.githubusercontent.com/9993/39684749-0bb0e50a-5173-11e8-9e11-d151211151c3.png)

Here it is normalized.

```python
alt.Chart(data).mark_area().encode(
    x="year:O",
    y=alt.Y("net_generation:Q", stack="normalize"),
    color="source:N"
)
```
![](https://user-images.githubusercontent.com/9993/39684741-010511c6-5173-11e8-85dc-da34f2bc1e2b.png)