### PR TITLE
fix: switch back to UMD bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ const outputs = [
       },
       {
         file: "build/vega-datasets.min.js",
-        format: "iife",
+        format: "umd",
         sourcemap: true,
         name: "vegaDatasets",
         plugins: [terser()],


### PR DESCRIPTION
fixes #391


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.5.2--canary.393.6152f95.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-datasets@2.5.2--canary.393.6152f95.0
  # or 
  yarn add vega-datasets@2.5.2--canary.393.6152f95.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
