### PR TITLE
Release

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ const outputs = [
       },
       {
         file: "build/vega-datasets.min.js",
-        format: "iife",
+        format: "umd",
         sourcemap: true,
         name: "vegaDatasets",
         plugins: [terser()],


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.2-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix: switch back to UMD bundles [#393](https://github.com/vega/vega-datasets/pull/393) ([@domoritz](https://github.com/domoritz))
  
  #### Authors: 1
  
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
