### PR TITLE
docs: adds missing reference to flare-dependencies.json to SOURCES.md

### DIFF
--- a/SOURCES.md
+++ b/SOURCES.md
@@ -87,7 +87,7 @@ https://archive.nytimes.com/www.nytimes.com/imagepages/2010/05/02/business/02met
 https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson
 (Feb 6, 2018)
 
-## `flare.json`
+## `flare.json`, `flare-dependencies.json`
 
 ## `flights-?k.json`, `flights-200k.arrow`, `flights-airport.csv`
 


### PR DESCRIPTION
SOURCES.md previously showed only a reference to `flare.json`, not to the related file `flare-dependencies.json` that [exists](https://github.com/vega/vega-datasets/blob/main/data/flare-dependencies.json) in the data folder