### PR TITLE
feat: Use a datetime column in `flights-3m.parquet`

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -21,7 +21,7 @@
     }
   ],
   "version": "2.11.0",
-  "created": "2024-12-04T12:47:49.897600+00:00",
+  "created": "2024-12-06T16:14:38.044099+00:00",
   "resources": [
     {
       "name": "7zip.png",
@@ -1060,7 +1060,7 @@
         "fields": [
           {
             "name": "date",
-            "type": "integer"
+            "type": "datetime"
           },
           {
             "name": "delay",

--- a/scripts/flights.py
+++ b/scripts/flights.py
@@ -446,35 +446,6 @@ def print_verbose_stats(stats: Dict[str, Any]) -> None:
             logging.info(f"  {', '.join(stats['airports']['destinations'])}")
     logging.info("\n")
 
-def save_output(
-    df: pd.DataFrame,
-    output_format: OutputFormat,
-    base_filename: str,
-    datetime_format: DateTimeFormat,
-    verbose: bool = False,
-    parquet_config: Optional[ParquetConfig] = None
-) -> None:
-    """Save the DataFrame in the specified format and optionally show statistics."""
-    if verbose:
-        stats = get_dataset_stats(df, datetime_format)
-        print_verbose_stats(stats)
-    
-    if output_format == OutputFormat.CSV:
-        output_file = f"{base_filename}.csv"
-        df.to_csv(output_file, index=False, encoding='utf-8')
-    elif output_format == OutputFormat.JSON:
-        output_file = f"{base_filename}.json"
-        records = df.to_dict(orient='records')
-        with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(records, f, separators=(',', ':'))
-    else:  # PARQUET
-        if parquet_config is None:
-            parquet_config = ParquetConfig()
-        output_file = f"{base_filename}.parquet"
-        save_as_parquet(df, output_file, parquet_config)
-    
-    logging.info(f"Successfully created {output_file} with {len(df)} rows")
-
 def add_parquet_arguments(parser: argparse.ArgumentParser) -> None:
     """Add Parquet-specific arguments to the parser."""
     parquet_group = parser.add_argument_group('Parquet options')

--- a/scripts/flights.py
+++ b/scripts/flights.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pandas",
+#     "pyarrow>=14.0.0",
+# ]
+# ///
 """
 Process U.S. DOT On-Time Flight Performance data into a simplified CSV/JSON/Parquet format.
 

--- a/scripts/flights.py
+++ b/scripts/flights.py
@@ -666,29 +666,23 @@ def save_output(
     output_format: OutputFormat,
     base_filename: str,
     datetime_format: DateTimeFormat,
+    parquet_config: ParquetConfig,
     verbose: bool = False,
-    parquet_config: Optional[ParquetConfig] = None
 ) -> None:
     """Save the DataFrame in the specified format and optionally show statistics."""
     if verbose:
         stats = get_dataset_stats(df, datetime_format)
         print_verbose_stats(stats)
-    
+    output_filename = f"{base_filename}.{output_format.value}"
     if output_format == OutputFormat.CSV:
-        output_file = f"{base_filename}.csv"
-        df.to_csv(output_file, index=False, encoding='utf-8')
+        df.to_csv(output_filename, index=False)
     elif output_format == OutputFormat.JSON:
-        output_file = f"{base_filename}.json"
-        records = df.to_dict(orient='records')
-        with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(records, f, separators=(',', ':'))
+        s = json.dumps(df.to_dict(orient="records"), separators=(",", ":"))
+        Path(output_filename).write_text(s, encoding="utf-8")
     else:  # PARQUET
-        if parquet_config is None:
-            parquet_config = ParquetConfig()
-        output_file = f"{base_filename}.parquet"
-        save_as_parquet(df, output_file, parquet_config)
-    
-    logging.info(f"Successfully created {output_file} with {len(df)} rows")
+        save_as_parquet(df, output_filename, parquet_config)
+
+    logging.info(f"Successfully created {output_filename} with {len(df)} rows")
 
 def main():
     args = parse_args()


### PR DESCRIPTION
Closes #641 

## Related
- https://github.com/vega/altair/pull/3631#issuecomment-2480816377

## Description

If I've understood the *existing* script correctly; then this should produce a datetime/timestamp column for `"date"`.
Or more correctly, it won't convert to a format string for `.parquet` - as it supports data types.

## Question

@dsmedia I haven't run the script, as I'm unsure on:

- What environment is needed for the script?
- How exactly is the [linked data](https://www.transtats.bts.gov/DL_SelectFields.asp?gnoyr_VQ=FGJ&QO_fu146_anzr=b0-gvzr) selected?
	- The doc says 1 per month
	- `flights-3m.parquet` has 6 months
	- `flights-?k.json` have 3 months?
- What were the most recent CLI args used?

### Update
In (https://github.com/vega/vega-datasets/pull/642/commits/a908adb8477c9b7cdebc42a77eda3c381b2c8292) I opted for making the change in place.

<details><summary>Fix script</summary>
<p>

```py
from pathlib import Path
import polars as pl

def fix_inplace_3m_parquet(
    fp: Path, /, year: int | str, *, column: str = "date"
) -> None:
    year_zero_pad = str(year)[-2:]
    if len(year_zero_pad) != 2:
        raise TypeError(year)

    ldf = pl.scan_parquet(fp)
    if not ldf.collect_schema()[column].is_temporal():
        date_conv: pl.Expr = (
            pl.concat_str(pl.lit(year_zero_pad), column)
            .str.to_datetime("%y%m%d%H%M")
            .alias(column)
        )
        ldf.with_columns(date_conv).collect().write_parquet(fp, compression_level=22)

>>> fix_inplace_3m_parquet(
...     Path.cwd() / "data" / "flights-3m.parquet", year=2001, column="date"
... )
```

</p>
</details> 

## Example
```py
from pathlib import Path
import polars as pl

>>> pl.read_parquet(Path.cwd() / "data" / "flights-3m.parquet")
shape: (3_000_000, 5)
┌─────────────────────┬───────┬──────────┬────────┬─────────────┐
│ date                ┆ delay ┆ distance ┆ origin ┆ destination │
│ ---                 ┆ ---   ┆ ---      ┆ ---    ┆ ---         │
│ datetime[μs]        ┆ i64   ┆ i64      ┆ str    ┆ str         │
╞═════════════════════╪═══════╪══════════╪════════╪═════════════╡
│ 2001-01-01 00:01:00 ┆ -13   ┆ 2345     ┆ ANC    ┆ LAX         │
│ 2001-01-01 00:03:00 ┆ -20   ┆ 1946     ┆ LAX    ┆ ATL         │
│ 2001-01-01 00:10:00 ┆ 0     ┆ 1671     ┆ PHX    ┆ DTW         │
│ 2001-01-01 00:20:00 ┆ 10    ┆ 1709     ┆ SEA    ┆ STL         │
│ 2001-01-01 00:22:00 ┆ -13   ┆ 1736     ┆ SFO    ┆ STL         │
│ …                   ┆ …     ┆ …        ┆ …      ┆ …           │
│ 2001-06-30 23:58:00 ┆ 30    ┆ 215      ┆ ATL    ┆ SAV         │
│ 2001-06-30 23:59:00 ┆ 87    ┆ 496      ┆ PIT    ┆ BOS         │
│ 2001-06-30 23:59:00 ┆ 9     ┆ 151      ┆ ATL    ┆ HSV         │
│ 2001-06-30 23:59:00 ┆ 83    ┆ 641      ┆ DFW    ┆ DEN         │
│ 2001-06-30 23:59:00 ┆ 16    ┆ 594      ┆ ATL    ┆ DTW         │
└─────────────────────┴───────┴──────────┴────────┴─────────────┘
```
