### PR TITLE
ci: adds python-specific `.gitignore` patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .mypy_cache
 build
 node_modules
+*/**/__pycache__
+.venv
+*/**/*.ipynb


### PR DESCRIPTION
Not as exhaustive as https://github.com/vega/altair/blob/main/.gitignore, but has been enough so far on my previous PRs