### PR TITLE
fix: Change default `.arrow` compression to `"uncompressed"`

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "2.11.0",
-  "created": "2024-12-31T12:05:10.822988+00:00",
+  "created": "2024-12-31T18:32:26.970186+00:00",
   "resources": [
     {
       "name": "7zip.png",
@@ -1080,7 +1080,7 @@
       "scheme": "file",
       "format": ".arrow",
       "mediatype": "application/vnd.apache.arrow.file",
-      "bytes": 4800864,
+      "bytes": 1600864,
       "schema": {
         "fields": [
           {

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "2.11.0",
-  "created": "2024-12-21T16:09:47.521815+00:00",
+  "created": "2024-12-31T12:05:10.822988+00:00",
   "resources": [
     {
       "name": "7zip.png",
@@ -1080,7 +1080,7 @@
       "scheme": "file",
       "format": ".arrow",
       "mediatype": "application/vnd.apache.arrow.file",
-      "bytes": 662832,
+      "bytes": 4800864,
       "schema": {
         "fields": [
           {

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`2.11.0` | [GitHub](http://github.com/vega/vega-datasets.git) | 2024-12-31 12:05:10 [UTC]
+`2.11.0` | [GitHub](http://github.com/vega/vega-datasets.git) | 2024-12-31 18:32:26 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`2.11.0` | [GitHub](http://github.com/vega/vega-datasets.git) | 2024-12-21 16:09:47 [UTC]
+`2.11.0` | [GitHub](http://github.com/vega/vega-datasets.git) | 2024-12-31 12:05:10 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 

--- a/scripts/flights.py
+++ b/scripts/flights.py
@@ -526,7 +526,7 @@ class Spec:
         kwds = self.write_options
         match self.suffix:
             case ".arrow":
-                df.write_ipc(fp, **kwds)
+                df.with_columns(pl.all().shrink_dtype()).write_ipc(fp, **kwds)
             case ".csv":
                 df.write_csv(fp, **kwds)
             case ".json":


### PR DESCRIPTION
Fixes #655

The file size of `flights-200k.arrow` has a ~~**7.2x**~~ **2.4x increase.**
However, this is still ~~roughly **half**~~ **0.16x** the size of `flights-200k.json`.

Also, adds support for overriding any `write_options` on a per-`Spec` basis.
This may be helpful if we later run into issues with https://github.com/vega/vega/issues/3961