### PR TITLE
feat: Adopt UAX-31 compliant dataset names

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -23,7 +23,7 @@
   "created": "2025-03-31T17:24:58.659124+00:00",
   "resources": [
     {
-      "name": "7zip.png",
+      "name": "icon_7zip",
       "type": "file",
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
@@ -47,7 +47,7 @@
       "bytes": 3969
     },
     {
-      "name": "airports.csv",
+      "name": "airports",
       "type": "table",
       "description": "Airports in the United States and its territories, including  major commercial, regional, \nand municipal airports. Contains information about each airport's location (latitude/longitude \ncoordinates), identification codes, name, city, state, and country.",
       "licenses": [
@@ -103,7 +103,7 @@
       }
     },
     {
-      "name": "annual-precip.json",
+      "name": "annual_precip",
       "type": "json",
       "description": "A raster grid of global annual precipitation for the year 2016 at a resolution 1 degree of lon/lat per cell.",
       "licenses": [
@@ -127,7 +127,7 @@
       "bytes": 266265
     },
     {
-      "name": "anscombe.json",
+      "name": "anscombe",
       "type": "table",
       "description": "Eleven (x,y) pairs of numbers, with means x̄=9.0 and ȳ=7.5, and identical linear regression \nlines (same slope and intercept) and correlation coefficients (approximately 0.816). When plotted, reveals starkly \ndifferent patterns: one shows a linear relationship, another a non-linear curve, the third a near-perfect linear \nrelationship disrupted by a single outlier, and the fourth a near-vertical line of points where a single outlier \nentirely dictates the regression.\n\nIn his 1973 paper \"Graphs in Statistical Analysis\" Yale Professor [Francis Anscombe](https://archives.yale.edu/repositories/12/resources/3711) uses these four datasets \nto argue that visualization is essential to good statistical work, not merely an optional supplement. This was a radical position at a \ntime when most statistical analysis was done through batch processing on mainframes with no graphical output. Serves \nas a powerful demonstration that identical summary statistics can mask radically different patterns in data, making the case that \nstatistical analysis should combine both numerical calculations and graphical examination.  \n",
       "sources": [
@@ -170,7 +170,7 @@
       }
     },
     {
-      "name": "barley.json",
+      "name": "barley",
       "type": "table",
       "description": "Yields of barley varieties from experiments conducted by the Minnesota Agricultural\nExperiment Station (MAES) across six sites in Minnesota. The USDA Technical Bulletin No. 735\n(December 1940) republished these yields data with explicit credit to MAES as the source.\n\nIt was analyzed by agronomists F.R. Immer, H.K. Hayes, and L. Powers in the 1934 paper \"Statistical Determination of Barley Varietal Adaption\".\n\nR.A. Fisher popularized its use in the field of statistics when he included it in his book \"The Design of Experiments\".\n\nSince then it has been used to demonstrate new visualization techniques, including the trellis charts developed by Richard Becker, William Cleveland and others in the 1990s.\n",
       "licenses": [
@@ -222,7 +222,7 @@
       }
     },
     {
-      "name": "birdstrikes.csv",
+      "name": "birdstrikes",
       "type": "table",
       "description": "Records of reported wildlife strikes received by the U.S. FAA",
       "licenses": [
@@ -306,7 +306,7 @@
       }
     },
     {
-      "name": "budget.json",
+      "name": "budget",
       "type": "table",
       "description": "Historical and forecasted federal revenue/receipts produced in 2016 by the U.S. Office of Management and Budget.",
       "licenses": [
@@ -627,7 +627,7 @@
       }
     },
     {
-      "name": "budgets.json",
+      "name": "budgets",
       "type": "table",
       "description": "U.S. federal budget projections and actual outcomes from 1980 through 2010. Originally [analyzed](https://archive.nytimes.com/www.nytimes.com/interactive/2010/02/02/us/politics/20100201-budget-porcupine-graphic.html) by The New York Times in 2010. \nReveals how budget forecasts made in any given year compared to what actually happened, \nwith positive values indicating surpluses (briefly seen around 2000) and negative values \nrepresenting deficits (reaching a particularly large value of -$1.78 trillion during the 2008-2009 financial crisis).",
       "licenses": [
@@ -675,7 +675,7 @@
       }
     },
     {
-      "name": "burtin.json",
+      "name": "burtin",
       "type": "table",
       "description": "Compares the performance of three antibiotics against 16 different bacteria. Based on graphic designer \nWill Burtin's 1951 visualization of antibiotic effectiveness, originally published in Scope Magazine and\nfeatured as an example in the Protovis project, a precursor to D3.js.\n\nNumerical values represent the minimum inhibitory concentration (MIC) of each antibiotic, \nmeasured in units per milliliter, with lower values indicating higher antibiotic\neffectiveness.\n\nAs noted in the Protovis example, \"Recreating this display revealed some minor errors in the original: a missing grid line at 0.01 μg/ml, and an exaggeration of some values for penicillin\".\n\nThe vega-datsets version is largely consistent with the Protovis version, with one correction (changing 'Brucella antracis' to the correct 'Bacillus anthracis') and the addition of a new column, 'Genus', to group related bacterial species together.\n\nThe caption of the original 1951 [visualization](https://graphicdesignarchives.org/wp-content/uploads/wmgda_8616c.jpg) \nreads as follows:\n\n> #### Antibacterial ranges of Neomycin, Penicillin and Streptomycin\n>\n>\n> The chart compares the in vitro sensitivities to neomycin of some of the common pathogens (gram+ in red and gram- in blue) with their sensitivities to penicillin, and streptomycin.\n>\n> The effectiveness of the antibiotics is expressed as the highest dilution in μ/ml. which inhibits the test organism.\n>\n> High dilutions are toward the periphery; consequently the length of the colored bar is proportional to the effectiveness.\n>\n> It is apparent that neomycin is especially effective against Staph. albus and aureus, Streph. fecalis, A. aerogenes, S. typhosa, E. coli, Ps. aeruginosa, Br. abortus, K. pneumoniae, Pr. vulgaris, S. schottmuelleri and M. tuberculosis.\n>\n> Unfortunately, some strains of proteus, pseudomonas and hemolytic streptococcus are resistant to neomycin, although the majority of these are sensitive to neomycin.\n>\n> It also inhibits actinomycetes, but is inactive against viruses and fungi. Its mode of action is not understood.\n",
       "licenses": [
@@ -736,7 +736,7 @@
       }
     },
     {
-      "name": "cars.json",
+      "name": "cars",
       "type": "table",
       "description": "Collection of car specifications and performance metrics from various automobile manufacturers.",
       "licenses": [
@@ -805,7 +805,7 @@
       }
     },
     {
-      "name": "co2-concentration.csv",
+      "name": "co2_concentration",
       "type": "table",
       "description": "Atmospheric CO2 concentration measurements from Mauna Loa Observatory, Hawaii. \nContains monthly readings from 1958-2020 with two key measurements:\n1. CO2 concentrations in millionths of a [mole](https://en.wikipedia.org/wiki/Mole_(unit)) of CO2 \nper mole of air (parts per million), reported on the 2012 \nSIO manometric mole fraction scale\n2. Seasonally adjusted values where a [4-harmonic fit](https://en.wikipedia.org/wiki/Harmonic_analysis) with linear gain factor \nhas been subtracted to remove the quasi-regular seasonal cycle\nValues are adjusted to 24:00 hours on the 15th of each month. \nOnly includes rows with valid data.\n",
       "licenses": [
@@ -849,7 +849,7 @@
       }
     },
     {
-      "name": "countries.json",
+      "name": "countries",
       "type": "table",
       "description": "Key demographic indicators (life expectancy at birth and fertility rate measured \nas babies per woman) for various countries from 1955 to 2000 at 5-year intervals. Includes both \ncurrent values and adjacent time period values (previous and next) for each indicator. Gapminder's \n[data documentation](https://www.gapminder.org/data/documentation/) notes that its philosophy is to fill data gaps with \nestimates and use current geographic boundaries for historical data. Gapminder states that it \naims to \"show people the big picture\" rather than support detailed numeric analysis.",
       "licenses": [
@@ -922,7 +922,7 @@
       }
     },
     {
-      "name": "crimea.json",
+      "name": "crimea",
       "type": "table",
       "description": "Monthly mortality rates from British military hospitals during the Crimean War (1854-1856), which informed \nFlorence Nightingale's groundbreaking work in public health. Nightingale credits Dr. William Farr for \ncompiling the data from the 1858 [Medical and Surgical History of the British Army](http://resource.nlm.nih.gov/62510370R). Categorizes \ndeaths into \"zymotic\" diseases (preventable infectious diseases), wounds/injuries, and other causes. \nCovering the period from April 1854 to March 1856, it includes monthly army strength \nalongside mortality figures. Transformed by Nightingale into her now-famous [polar area \ndiagrams](https://iiif.lib.harvard.edu/manifests/view/drs:7420433$25i). \n\nThe annual mortality rates plotted in the chart can be calculated using the formula \n> (Deaths &times; 1000 &times; 12) &divide; Army Size. \n\nAs [The Lancet](https://pmc.ncbi.nlm.nih.gov/articles/PMC7252134/) argued in 2020, Nightingale's \ninnovative visualizations proved that \"far more men died of disease, infection, and exposure \nthan in battle—a fact that shocked the British nation.\" Her work also vividly illustrated \nthe dramatic impact of sanitary reforms, particularly in reducing preventable deaths.",
       "licenses": [
@@ -980,7 +980,7 @@
       }
     },
     {
-      "name": "disasters.csv",
+      "name": "disasters",
       "type": "table",
       "description": "Annual number of deaths from disasters, sourced from EM-DAT (Emergency Events Database) \nmaintained by the Centre for Research on the Epidemiology of Disasters (CRED) at UCLouvain, Belgium. \nProcessed by Our World in Data to standardize country names and world region definitions, converting units,\ncalculating derived indicators, and adapting metadata. Deaths are reported as absolute numbers.",
       "licenses": [
@@ -1028,7 +1028,7 @@
       }
     },
     {
-      "name": "driving.json",
+      "name": "driving",
       "type": "table",
       "description": "Tracks the relationship between driving habits and gasoline prices \nin the United States during a period spanning multiple significant events, including \nthe cheap gas era, Arab oil embargo, energy crisis, record low prices, and the \n\"swing backward\" from 1956 to 2010.\n",
       "sources": [
@@ -1081,7 +1081,7 @@
       }
     },
     {
-      "name": "earthquakes.json",
+      "name": "earthquakes",
       "type": "json",
       "description": "Represents approximately one week of continuous monitoring from USGS's \"all earthquakes\" \nreal-time feed, which includes 1,703 seismic events of all magnitudes recorded by the \nUSGS Earthquake Hazards Program from January 31 to February 7, 2018 (UTC). ",
       "licenses": [
@@ -1105,7 +1105,7 @@
       "bytes": 1219853
     },
     {
-      "name": "ffox.png",
+      "name": "icon_firefox",
       "type": "file",
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
@@ -1129,7 +1129,7 @@
       "bytes": 17628
     },
     {
-      "name": "flare-dependencies.json",
+      "name": "flare_dependencies",
       "type": "table",
       "description": "Indicates, with `flare.json`, relationships among classes in a software hierarchy.",
       "path": "flare-dependencies.json",
@@ -1158,7 +1158,7 @@
       }
     },
     {
-      "name": "flare.json",
+      "name": "flare",
       "type": "table",
       "description": "Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy.",
       "path": "flare.json",
@@ -1187,7 +1187,7 @@
       }
     },
     {
-      "name": "flights-10k.json",
+      "name": "flights_10k",
       "type": "table",
       "description": "Flight delay statistics (10,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1241,7 +1241,7 @@
       }
     },
     {
-      "name": "flights-200k.arrow",
+      "name": "flights_200k_arrow",
       "type": "table",
       "description": "Flight delay statistics (200,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1281,7 +1281,7 @@
       }
     },
     {
-      "name": "flights-200k.json",
+      "name": "flights_200k",
       "type": "table",
       "description": "Flight delay statistics (200,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1327,7 +1327,7 @@
       }
     },
     {
-      "name": "flights-20k.json",
+      "name": "flights_20k",
       "type": "table",
       "description": "Flight delay statistics (20,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1381,7 +1381,7 @@
       }
     },
     {
-      "name": "flights-2k.json",
+      "name": "flights_2k",
       "type": "table",
       "description": "Flight delay statistics (2,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1435,7 +1435,7 @@
       }
     },
     {
-      "name": "flights-3m.parquet",
+      "name": "flights_3m_parquet",
       "type": "table",
       "description": "Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1483,7 +1483,7 @@
       }
     },
     {
-      "name": "flights-5k.json",
+      "name": "flights_5k",
       "type": "table",
       "description": "Flight delay statistics (5,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1537,7 +1537,7 @@
       }
     },
     {
-      "name": "flights-airport.csv",
+      "name": "flights_airport",
       "type": "table",
       "description": "Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id), \na destination airport, and the count of flights along this route.",
       "licenses": [
@@ -1580,7 +1580,7 @@
       }
     },
     {
-      "name": "football.json",
+      "name": "football",
       "type": "table",
       "description": "Football match outcomes across multiple divisions from 2013 to 2017, part of a\nlarger dataset from OpenFootball. The subset was made such that there are records for all five\nchosen divisions over the time period.",
       "licenses": [
@@ -1636,7 +1636,7 @@
       }
     },
     {
-      "name": "gapminder-health-income.csv",
+      "name": "gapminder_health_income",
       "type": "table",
       "description": "Per-capita income, life expectancy, population and regional grouping. Reference year for the data is not specified. \nGapminder historical data is subject to revisions.\n\nGapminder (v30, 2023) defines per-capita income as follows:\n>\"This is real GDP per capita (gross domestic product per person adjusted for inflation) \n>converted to international dollars using purchasing power parity rates. An international dollar \n>has the same purchasing power over GDP as the U.S. dollar has in the United States.\"\n",
       "licenses": [
@@ -1688,7 +1688,7 @@
       }
     },
     {
-      "name": "gapminder.json",
+      "name": "gapminder",
       "type": "table",
       "description": "Combines key demographic indicators (life expectancy at birth, \npopulation, and fertility rate measured as babies per woman) for various countries from 1955 \nto 2005 at 5-year intervals. Includes a 'cluster' column, a categorical variable \ngrouping countries. Gapminder's data documentation notes that its philosophy is to fill data \ngaps with estimates and use current geographic boundaries for historical data. Gapminder \nstates that it aims to \"show people the big picture\" rather than support detailed numeric \nanalysis.\n\nNotes:\n1. Country Selection: The set of countries matches the version of this dataset \n   originally added to this collection in 2015. The specific criteria for country selection \n   in that version are not known. Data for Aruba are no longer available in the new version. \n   Hong Kong has been revised to Hong Kong, China in the new version.\n\n2. Data Precision: The precision of float values may have changed from the original version. \n   These changes reflect the most recent source data used for each indicator.\n\n3. Regional Groupings: To preserve continuity with previous versions of this dataset, we have retained the column \n   name 'cluster' instead of renaming it to 'six_regions'. \n",
       "licenses": [
@@ -1813,7 +1813,7 @@
       }
     },
     {
-      "name": "gimp.png",
+      "name": "icon_gimp",
       "type": "file",
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
@@ -1836,7 +1836,7 @@
       "bytes": 8211
     },
     {
-      "name": "github.csv",
+      "name": "github",
       "type": "table",
       "description": "Simulated GitHub contribution data showing hourly commit counts across \ndifferent times of day. Designed to demonstrate typical patterns of developer activity \nin a GitHub-style punchcard visualization format.",
       "licenses": [
@@ -1872,7 +1872,7 @@
       }
     },
     {
-      "name": "global-temp.csv",
+      "name": "global_temp",
       "type": "table",
       "description": "Combined Land-Surface Air and Sea-Surface Water Temperature Anomalies (Land-Ocean Temperature Index, L-OTI), 1880-2023.",
       "licenses": [
@@ -1908,7 +1908,7 @@
       }
     },
     {
-      "name": "income.json",
+      "name": "income",
       "type": "table",
       "description": "Household income distribution by US state, derived from the \nCensus Bureau's American Community Survey 3-Year Data (2013). The dataset \nshows the percentage of households within different income brackets for each state.\nGenerated using `/scripts/income.py`. This product uses the Census Bureau Data API \nbut is not endorsed or certified by the Census Bureau.",
       "licenses": [
@@ -1970,7 +1970,7 @@
       }
     },
     {
-      "name": "iowa-electricity.csv",
+      "name": "iowa_electricity",
       "type": "table",
       "description": "Annual net generation of electricity in Iowa by source, in thousand megawatthours. U.S. EIA data downloaded on May 6, 2018. \nUseful for illustrating stacked area charts. Demonstrates dramatic increase in wind power production.",
       "licenses": [
@@ -2010,7 +2010,7 @@
       }
     },
     {
-      "name": "jobs.json",
+      "name": "jobs",
       "type": "table",
       "description": "U.S. census data on [occupations](https://usa.ipums.org/usa-action/variables/OCC1950#codes_section) by sex and year across decades between 1850 and 2000. Obtained from IPUMS USA, which \"collects, preserves and harmonizes U.S. census microdata\" from as early as 1790.\n\nOriginally created for a 2006 data visualization project called *sense.us* by IBM Research (Jeff Heer, Martin Wattenberg and Fernanda Viégas), described [here](https://homes.cs.washington.edu/~jheer/files/bdata_ch12.pdf). \nThe dataset is also referenced in this vega [example](https://vega.github.io/vega/examples/job-voyager/).\n\nBased on a tabulation of the [OCC1950](https://usa.ipums.org/usa-action/variables/OCC1950) variable by sex across IPUMS USA samples. Appears to be derived from Version 6.0 (2015) of IPUMS USA, according to 2024 correspondence with the IPUMS Project. IPUMS has made improvements to occupation coding since version 6, particularly for 19th-century samples, which may result in discrepancies between this dataset and current IPUMS data. Details on data revisions are available [here](https://usa.ipums.org/usa-action/revisions).\n\nIPUMS USA confirmed in 2024 correspondence that hosting this dataset on vega-datasets is permissible, stating:\n>We're excited to hear that this dataset made its way to this repository and is being used by students for data visualization. We allow for these types of redistributions of summary data so long as the underlying microdata records are not shared.\n\n1. Represents summary data. Underlying microdata records are not included.\n2. Users attempting to replicate or extend this data should use the [PERWT](https://usa.ipums.org/usa-action/variables/PERWT#description_section) \n(person weight) variable as an expansion factor when working with IPUMS USA extracts.\n3. Due to coding revisions, figures for earlier years (particularly 19th century) may not match current IPUMS USA data exactly.\n\nWhen using this dataset, please refer to IPUMS USA [terms of use](https://usa.ipums.org/usa/terms.shtml).\nThe organization requests use of the following citation for this json file:\n\nSteven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. Integrated Public Use Microdata Series: Version 6.0. Minneapolis: University of Minnesota, 2015. http://doi.org/10.18128/D010.V6.0\n",
       "licenses": [
@@ -2069,7 +2069,7 @@
       }
     },
     {
-      "name": "la-riots.csv",
+      "name": "la_riots",
       "type": "table",
       "description": "A comprehensive record of fatalities during the five days of civil unrest in Los Angeles beginning \nApril 29, 1992, documenting over 60 deaths with associated geographic coordinates where each person lost their life.\nOriginally compiled and published by the Los Angeles Times Data Desk.",
       "sources": [
@@ -2135,7 +2135,7 @@
       }
     },
     {
-      "name": "londonboroughs.json",
+      "name": "londonboroughs",
       "type": "json",
       "description": "Boundaries of London boroughs reprojected and simplified from `London_Borough_Excluding_MHW` shapefile. \nOriginal data \"contains National Statistics data © Crown copyright and database right (2015)\" \nand \"Contains Ordnance Survey data © Crown copyright and database right [2015].",
       "licenses": [
@@ -2159,7 +2159,7 @@
       "bytes": 14732
     },
     {
-      "name": "londoncentroids.json",
+      "name": "londoncentroids",
       "type": "table",
       "description": "Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/d3-geo/math#geoCentroid).",
       "licenses": [
@@ -2204,7 +2204,7 @@
       }
     },
     {
-      "name": "londontubelines.json",
+      "name": "londontubelines",
       "type": "json",
       "description": "A [topologically-encoded](https://github.com/topojson/topojson) representation of select London Underground rail lines, derived from OpenStreetMap\ndata. These 394 LineString geometries, encoded using 406 arcs, depict transport paths between stations with stations marked as nodes\nalong the lines. Originally transformed from a GeoJSON intermediary `tfl_lines.json` into TopoJSON format, this network configuration \nreflects the system as of February 4, 2018, and may not incorporate subsequent modifications or expansions.\n",
       "licenses": [
@@ -2228,7 +2228,7 @@
       "bytes": 80097
     },
     {
-      "name": "lookup_groups.csv",
+      "name": "lookup_groups",
       "type": "table",
       "description": "A nine-row lookup table for the `lookup_people.csv` dataset, \nmapping people to groups. Used to [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup` transforms.",
       "licenses": [
@@ -2262,7 +2262,7 @@
       }
     },
     {
-      "name": "lookup_people.csv",
+      "name": "lookup_people",
       "type": "table",
       "description": "A synthetic list of nine people and their associated name, age, \nand height in centimeters. Used in conjunction with `lookup_groups.csv` \nto [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup` transforms.",
       "licenses": [
@@ -2300,7 +2300,7 @@
       }
     },
     {
-      "name": "miserables.json",
+      "name": "miserables",
       "type": "json",
       "description": "A weighted network of coappearances of characters in Victor Hugo's novel \"Les Miserables\". \nNodes represent characters as indicated by the labels and edges connect any pair of characters \nthat appear in the same chapter of the book. The values on the edges are the number of such \ncoappearances.\n",
       "licenses": [
@@ -2323,7 +2323,7 @@
       "bytes": 12372
     },
     {
-      "name": "monarchs.json",
+      "name": "monarchs",
       "type": "table",
       "description": "A chronological list of English and British monarchs from Elizabeth I through George IV.\n\nContains two intentional inaccuracies to maintain compatibility with \nthe [Wheat and Wages](https://vega.github.io/vega/examples/wheat-and-wages/) example visualization:\n1. the start date for the reign of Elizabeth I is shown as 1565, instead of 1558;\n2. the end date for the reign of George IV is shown as 1820, instead of 1830.\nThese discrepancies align the `monarchs.json` dataset with the start and end dates of the `wheat.json` dataset used in the visualization.\nThe entry \"W&M\" represents the joint reign of William III and Mary II. While the dataset shows their reign as 1689-1702, \nthe official Web site of the British royal family indicates that Mary II's reign ended in 1694, though William III continued to rule until 1702.\nThe `commonwealth` field is used to flag the period from 1649 to 1660, which includes the Commonwealth of England, the Protectorate, \nand the period leading to the Restoration. While historically more accurate to call this the \"interregnum,\" the field name of `commonwealth` \nfrom the original dataset is retained for backwards compatibility.\n\n> [!IMPORTANT]\n> Revised in Aug. 2024 to show James II's reign now ends in 1688 (previously 1689).\n\nSource data has been verified against the kings & queens and interregnum pages of the official website of the British royal family (retrieved in Aug. 2024).\n",
       "licenses": [
@@ -2380,7 +2380,7 @@
       }
     },
     {
-      "name": "movies.json",
+      "name": "movies",
       "type": "table",
       "description": "A collection of films and their performance metrics, including box office earnings, budgets, \nand audience ratings. Contains known data quality issues and intentional errors, serving as a teaching \nresource for developing data cleaning and validation skills in real-world analysis workflows.",
       "path": "movies.json",
@@ -2465,7 +2465,7 @@
       }
     },
     {
-      "name": "normal-2d.json",
+      "name": "normal_2d",
       "type": "table",
       "description": "Five hundred paired coordinates sampled from a bivariate normal distribution. The data is centered near the \norigin with standard deviations indicating a relatively equal spread in both dimensions. \nThe variables exhibit negligible correlation (0.026), suggesting independence. \n[Normality tests](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.normaltest.html) for each variable yield high p-values, supporting the normal distribution assumption. \nThese characteristics make it well-suited for demonstrating statistical visualization techniques \nin Vega and Vega-Lite, including scatter plots, density plots, heatmaps, and marginal histograms/density curves. \nIt can also serve as a clean baseline for testing new visualization methods or for educational purposes \nin data visualization and statistics.\nA contrast to uniformly distributed data in `uniform-2d.json`\n",
       "licenses": [
@@ -2506,7 +2506,7 @@
       }
     },
     {
-      "name": "obesity.json",
+      "name": "obesity",
       "type": "table",
       "description": "State-level obesity rates (BMI >= 30) for the U.S. in 1995. \nOriginally [Behavioral Risk Factor Surveillance System (BRFSS)](https://www.cdc.gov/brfss/index.html) statistics.",
       "licenses": [
@@ -2551,7 +2551,7 @@
       }
     },
     {
-      "name": "ohlc.json",
+      "name": "ohlc",
       "type": "table",
       "description": "Performance of the Chicago Board Options Exchange \n[Volatility Index](https://en.wikipedia.org/wiki/VIX) (VIX) in the summer of 2009.\n\nThe precise methodology used to derive the signal and calculate the ret columns is unclear.\n",
       "sources": [
@@ -2610,7 +2610,7 @@
       }
     },
     {
-      "name": "penguins.json",
+      "name": "penguins",
       "type": "table",
       "description": "Records of morphological measurements and demographic information from 344 Palmer Archipelago \npenguins across three species. Collected by [Dr. Kristen Gorman](https://www.uaf.edu/cfos/people/faculty/detail/kristen-gorman.php) and the Palmer Station Antarctica [LTER](https://lternet.edu/). \nData gathering occurred as part of Palmer Station's long-term ecological research, contributing to studies of Antarctic marine\necosystems and penguin biology. All measurements follow standardized units, enabling research into morphological \nvariations between species and sexual dimorphism in Antarctic penguins. \n",
       "licenses": [
@@ -2682,7 +2682,7 @@
       }
     },
     {
-      "name": "platformer-terrain.json",
+      "name": "platformer_terrain",
       "type": "table",
       "description": "Assets from the video game Celeste. Added in [#376](https://github.com/vega/vega-datasets/pull/376)",
       "sources": [
@@ -2741,7 +2741,7 @@
       }
     },
     {
-      "name": "political-contributions.json",
+      "name": "political_contributions",
       "type": "table",
       "description": "Summary financial information on contributions to candidates for U.S. \nelections. An updated version is available from the \"all candidates\" files (in pipe-delimited format)\non the bulk data download page of the U.S. Federal Election Commission, or, alternatively, via OpenFEC. \nInformation on each of the 25 columns is available from the [FEC All Candidates File Description](https://www.fec.gov/campaign-finance-data/all-candidates-file-description/).\nThe sample dataset in `political-contributions.json` contains 58 records with dates from 2015.\n\nFEC data is subject to the commission's:\n- [Sale or Use Policy](https://www.fec.gov/updates/sale-or-use-contributor-information/)\n- [Privacy and Security Policy](https://www.fec.gov/about/privacy-and-security-policy/)\n- [Acceptable Use Policy](https://github.com/fecgov/FEC/blob/master/ACCEPTABLE-USE-POLICY.md)\n\nAdditionally, the FEC's Github [repository](https://github.com/fecgov/FEC) states:\n> This project is in the public domain within the United States, and we waive worldwide \n> copyright and related rights through [CC0 universal public domain](https://creativecommons.org/publicdomain/zero/1.0/)\n> dedication. Read more on our [license](https://github.com/fecgov/FEC?tab=License-1-ov-file) page.\n> A few restrictions limit the way you can use FEC data. For example, you can't use \n> contributor lists for commercial purposes or to solicit donations. Learn more on \n> [FEC.gov](https://www.fec.gov/).",
       "licenses": [
@@ -2878,7 +2878,7 @@
       }
     },
     {
-      "name": "population.json",
+      "name": "population",
       "type": "table",
       "description": "U.S. population counts by age group (0-90+ in 5-year intervals) and sex \nfor each decade between 1850 and 2000, collected and harmonized from historical census records by IPUMS USA.\n\nIPUMS updates and revises datasets over time, which may result in discrepancies with current IPUMS data.\n\nWhen using this dataset, please refer to IPUMS USA terms of use. The organization requests the \nuse of the following citation for this json file:\nSteven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. Integrated \nPublic Use Microdata Series: Version 6.0. Minneapolis: University of Minnesota, 2015. \nhttp://doi.org/10.18128/D010.V6.0\n",
       "licenses": [
@@ -2931,7 +2931,7 @@
       }
     },
     {
-      "name": "population_engineers_hurricanes.csv",
+      "name": "population_engineers_hurricanes",
       "type": "table",
       "description": "Per-state population, number of engineers, and hurricanes. Used in Vega-Lite example,\n[Three Choropleths Representing Disjoint Data from the Same Table](https://vega.github.io/vega-lite/examples/geo_repeat.html)",
       "licenses": [
@@ -2987,7 +2987,7 @@
       }
     },
     {
-      "name": "seattle-weather-hourly-normals.csv",
+      "name": "seattle_weather_hourly_normals",
       "type": "table",
       "description": "Hourly weather normals with metric units. The 1981-2010 Climate Normals are \nNCDC's three-decade averages of climatological variables, including temperature and \nprecipitation. Learn more in the [documentation](https://www1.ncdc.noaa.gov/pub/data/cdo/documentation/NORMAL_HLY_documentation.pdf).\nWe only included temperature, wind, and pressure \nand updated the format to be easier to parse.",
       "licenses": [
@@ -3031,7 +3031,7 @@
       }
     },
     {
-      "name": "seattle-weather.csv",
+      "name": "seattle_weather",
       "type": "table",
       "description": "Daily weather in metric units. Transformed using `/scripts/weather.py`. \nThe categorical \"weather\" field is synthesized from multiple fields in the original dataset. \nThis data is intended for instructional purposes.",
       "licenses": [
@@ -3096,7 +3096,7 @@
       }
     },
     {
-      "name": "sp500-2000.csv",
+      "name": "sp500_2000",
       "type": "table",
       "description": "S&amp;P 500 index values from 2000 to 2020.",
       "sources": [
@@ -3146,7 +3146,7 @@
       }
     },
     {
-      "name": "sp500.csv",
+      "name": "sp500",
       "type": "table",
       "description": "Monthly closing values of the S&P 500 stock market index \nfrom January 2000 to March 2010. Captures several significant market events including \nthe dot-com bubble burst (2000-2002), the mid-2000s bull market, and the 2008 financial crisis. \n",
       "path": "sp500.csv",
@@ -3172,7 +3172,7 @@
       }
     },
     {
-      "name": "species.csv",
+      "name": "species",
       "type": "table",
       "description": "Percentage of year-round habitat for four species -- American robin, white-tailed deer, \nAmerican bullfrog, and common gartersnake -- within US counties, derived from USGS \nGap Analysis Project (GAP) Species Habitat Maps. Data is provided at a 30-meter \nresolution and covers the contiguous United States. Habitat percentages are calculated \nby overlaying species habitat rasters (year-round habitat represented by value 3) with \nUS county boundaries.\n\nThe habitat maps are in Albers Conical Equal Area projection (EPSG:5070). County boundaries \nare derived from US Census Bureau cartographic boundary files (1:10,000,000 scale), from \n`US-10m.json` in this repository. This dataset only includes *year-round* habitat. \nThe original raster data also contains values for summer and winter habitat, which are \n*not* included in this dataset. Data was processed using the `exactextract` library \nfor zonal statistics.\n",
       "licenses": [
@@ -3234,7 +3234,7 @@
       }
     },
     {
-      "name": "stocks.csv",
+      "name": "stocks",
       "type": "table",
       "description": "Monthly stock prices for five companies from 2000 to 2010.",
       "path": "stocks.csv",
@@ -3262,7 +3262,7 @@
       }
     },
     {
-      "name": "udistrict.json",
+      "name": "udistrict",
       "type": "table",
       "description": "Point locations of restaurants and cafes in Seattle's University \nDistrict, categorized by cuisine type. Used to create a [ridgeline plot example](https://vega.github.io/vega/examples/u-district-cuisine/) \nshowing the prevalence of various food and beverage categories. The example graphic \nusing this dataset states that it originally appeared in Alaska Airlines Beyond Magazine (Sep 2017, p. 120)",
       "path": "udistrict.json",
@@ -3291,7 +3291,7 @@
       }
     },
     {
-      "name": "unemployment-across-industries.json",
+      "name": "unemployment_across_industries",
       "type": "table",
       "description": "Industry-level unemployment from the Current Population Survey \n(CPS), published monthly by the U.S. Bureau of Labor Statistics. Includes unemployed persons \nand unemployment rate across 11 private industries, as well as agricultural, government, and \nself-employed workers. Covers January 2000 through February 2010. Industry classification \nfollows format of CPS Table A-31. Transformed using `scripts/make-unemployment-across-industries.py`\n\nThe BLS Web site states:\n> \"Users of the public API should cite the date that data were accessed or retrieved using \n> the API. Users must clearly state that \"BLS.gov cannot vouch for the data or analyses \n> derived from these data after the data have been retrieved from BLS.gov.\" The BLS.gov logo \n> may not be used by persons who are not BLS employees or on products (including web pages) \n> that are not BLS-sponsored.\"\n\nSee full BLS [terms of service](https://www.bls.gov/developers/termsOfService.htm).",
       "licenses": [
@@ -3409,7 +3409,7 @@
       }
     },
     {
-      "name": "uniform-2d.json",
+      "name": "uniform_2d",
       "type": "table",
       "description": "Five hundred paired coordinates (u, v) sampled from a bivariate uniform distribution. Centered near the\norigin with ranges spanning approximately [-0.5, 0.5] in both dimensions. The variables exhibit negligible\ncorrelation (-0.019), suggesting independence, as expected for a uniform distribution.\nA contrast to normally distributed data in `normal-2d.json`.\n",
       "licenses": [
@@ -3450,7 +3450,7 @@
       }
     },
     {
-      "name": "us-10m.json",
+      "name": "us_10m",
       "type": "json",
       "description": "US county boundaries represented at a 1:10,000,000 scale in \n[TopoJSON](https://github.com/topojson/topojson) format, which optimizes for \nsmaller file sizes. Similar to offerings in the TopoJSON US Atlas collection, which \nin turn is a redistribution of the Census Bureau's cartographic boundary shapefiles.\n",
       "licenses": [
@@ -3478,7 +3478,7 @@
       "bytes": 642361
     },
     {
-      "name": "us-employment.csv",
+      "name": "us_employment",
       "type": "table",
       "description": "Monthly employment total in a variety of job categories from January 2006 through December 2015, \nseasonally adjusted and reported in thousands. Downloaded and reformatted on Nov. 11, 2018.\n\nIn the mid 2000s the global economy was hit by a crippling recession. One result: Massive job \nlosses across the United States. The downturn in employment, and the slow recovery in hiring that \nfollowed, was tracked each month by the Current Employment Statistics program at the U.S. Bureau \nof Labor Statistics.\n\nTotals are included for the [22 \"supersectors\"](https://download.bls.gov/pub/time.series/ce/ce.supersector)\ntracked by the BLS. The \"nonfarm\" total is the category typically used by \neconomists and journalists as a stand-in for the country's employment total.\n\nA calculated \"nonfarm_change\" column has been appended with the month-to-month change in that \nsupersector's employment. It is useful for illustrating how to make bar charts that report both \nnegative and positive values.\n",
       "licenses": [
@@ -3602,7 +3602,7 @@
       }
     },
     {
-      "name": "us-state-capitals.json",
+      "name": "us_state_capitals",
       "type": "table",
       "description": "Geographical coordinates and names of U.S. state capitals, transformed using `scripts/us-state-capitals.py`. \nIncludes latitude, longitude, state name, and capital city name for all 50 U.S. states. \nCities are represented as point locations of their capitol buildings using coordinates in the \nWGS84 geographic coordinate system.\n\nAccording to [USGS]((https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map))\n> \"Map services and data downloaded from The National Map are free and in the public domain. \n> There are no restrictions; however, we request that the following acknowledgment statement \n> of the originating agency be included in products and data derived from our map services \n> when citing, copying, or reprinting: Map services and data available from U.S. \n> Geological Survey, National Geospatial Program.\"\n",
       "licenses": [
@@ -3655,7 +3655,7 @@
       }
     },
     {
-      "name": "volcano.json",
+      "name": "volcano",
       "type": "json",
       "description": "Elevation measurements of Maunga Whau (Mt Eden), a volcano in Auckland, New Zealand, representing \na rectangular area of 870 meters by 610 meters. Spacing between measurement points is approximately \n10 meters in both directions. Digitized from a topographic map by Ross Ihaka and adapted from R datasets, \nShould not be regarded as accurate.",
       "sources": [
@@ -3673,7 +3673,7 @@
       "bytes": 21167
     },
     {
-      "name": "weather.csv",
+      "name": "weather",
       "type": "table",
       "description": "Daily weather observations from Seattle and New York.\nTransformed from NOAA data using the script `/scripts/weather.py`.\nThe categorical \"weather\" field is synthesized from multiple fields in the original dataset.\nIntended for instructional purposes.",
       "licenses": [
@@ -3743,7 +3743,7 @@
       }
     },
     {
-      "name": "weekly-weather.json",
+      "name": "weekly_weather",
       "type": "json",
       "description": "Instructional dataset showing actual and predicted temperature data.\n\n> [!IMPORTANT]\n> Named `weather.json` in previous versions (`v1.4.0` - `v2.11.0`).\n",
       "path": "weekly-weather.json",
@@ -3755,7 +3755,7 @@
       "bytes": 1281
     },
     {
-      "name": "wheat.json",
+      "name": "wheat",
       "type": "table",
       "description": "As noted by in this protovis [example](https://mbostock.github.io/protovis/ex/wheat.html),\n\"In an 1822 letter to Parliament, [William Playfair](https://en.wikipedia.org/wiki/William_Playfair), a Scottish engineer \nwho is often credited as the founder of statistical graphics, published an elegant chart \non the price of wheat. It plots 250 years of prices alongside weekly wages and the reigning monarch. \nHe intended to demonstrate that:\n> 'never at any former period was wheat so cheap, in proportion to mechanical labour, as it is at the present time.'\"\n",
       "licenses": [
@@ -3800,7 +3800,7 @@
       }
     },
     {
-      "name": "windvectors.csv",
+      "name": "windvectors",
       "type": "table",
       "description": "Simulated wind patterns over northwestern Europe.",
       "path": "windvectors.csv",
@@ -3836,7 +3836,7 @@
       }
     },
     {
-      "name": "world-110m.json",
+      "name": "world_110m",
       "type": "json",
       "description": "A 1:110,000,000-scale world map in [TopoJSON](https://github.com/topojson/topojson) format, optimized for \nweb-based visualization. The simplified geographic boundaries focus on two key elements: \nland masses and country borders with their corresponding codes. The high level of \ngeneralization removes small geographic details while maintaining recognizable global \nfeatures, making it ideal for overview maps and basic world visualizations. This format \nprovides efficient compression compared to GeoJSON, reducing file size for web use. \nPart of the widely-used TopoJSON World Atlas collection, this has become a standard \nresource for creating web-based world maps where precise boundary detail isn't required.\n",
       "licenses": [
@@ -3868,7 +3868,7 @@
       "bytes": 119410
     },
     {
-      "name": "zipcodes.csv",
+      "name": "zipcodes",
       "type": "table",
       "description": "Postal codes mapped to their geographical coordinates (latitude/longitude in WGS84) \nand administrative hierarchies, for the United States and Puerto Rico. The GeoNames \ngeographical database provides worldwide postal code data with associated geographical \nand administrative information. \n\nHistorical snapshot first contributed to vega-datasets in 2017 and no longer current. \nAdministrative boundaries have been redrawn, counties reorganized and renamed, and postal \ncodes modified. Latitude/longitude coordinates have been updated by Geonames since this \ndata was collected. For current postal code data, refer to the main GeoNames database.",
       "licenses": [

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "3.1.0",
-  "created": "2025-03-31T17:24:58.659124+00:00",
+  "created": "2025-07-01T22:14:24.642423+00:00",
   "resources": [
     {
       "name": "icon_7zip",
@@ -1105,7 +1105,7 @@
       "bytes": 1219853
     },
     {
-      "name": "icon_firefox",
+      "name": "ffox",
       "type": "file",
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
@@ -1281,7 +1281,7 @@
       }
     },
     {
-      "name": "flights_200k",
+      "name": "flights_200k_json",
       "type": "table",
       "description": "Flight delay statistics (200,000 rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1435,7 +1435,7 @@
       }
     },
     {
-      "name": "flights_3m_parquet",
+      "name": "flights_3m",
       "type": "table",
       "description": "Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics. \nCollected under regulatory reporting requirements (14 CFR Part 234), which mandate \nthat qualifying airlines report on-time performance data to BTS. Transformed using \n`/scripts/flights.py`",
       "licenses": [
@@ -1813,7 +1813,7 @@
       }
     },
     {
-      "name": "icon_gimp",
+      "name": "gimp",
       "type": "file",
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
@@ -2135,7 +2135,7 @@
       }
     },
     {
-      "name": "londonboroughs",
+      "name": "londonBoroughs",
       "type": "json",
       "description": "Boundaries of London boroughs reprojected and simplified from `London_Borough_Excluding_MHW` shapefile. \nOriginal data \"contains National Statistics data © Crown copyright and database right (2015)\" \nand \"Contains Ordnance Survey data © Crown copyright and database right [2015].",
       "licenses": [
@@ -2159,7 +2159,7 @@
       "bytes": 14732
     },
     {
-      "name": "londoncentroids",
+      "name": "londonCentroids",
       "type": "table",
       "description": "Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/d3-geo/math#geoCentroid).",
       "licenses": [
@@ -2204,7 +2204,7 @@
       }
     },
     {
-      "name": "londontubelines",
+      "name": "londonTubeLines",
       "type": "json",
       "description": "A [topologically-encoded](https://github.com/topojson/topojson) representation of select London Underground rail lines, derived from OpenStreetMap\ndata. These 394 LineString geometries, encoded using 406 arcs, depict transport paths between stations with stations marked as nodes\nalong the lines. Originally transformed from a GeoJSON intermediary `tfl_lines.json` into TopoJSON format, this network configuration \nreflects the system as of February 4, 2018, and may not incorporate subsequent modifications or expansions.\n",
       "licenses": [
@@ -3362,7 +3362,7 @@
       }
     },
     {
-      "name": "unemployment.tsv",
+      "name": "unemployment",
       "type": "table",
       "description": "County-level unemployment rates in the United States, with data generally\nconsistent with levels reported in 2009. The dataset is structured as tab-separated values.\nThe unemployment rate represents the number of unemployed persons as a percentage of the labor\nforce. According to the Bureau of Labor Statistics (BLS) glossary:\n\nUnemployed persons (Current Population Survey) [are] persons aged 16 years and older who had\nno employment during the reference week, were available for work, except for temporary\nillness, and had made specific efforts to find employment sometime during the 4-week period\nending with the reference week. Persons who were waiting to be recalled to a job from which\nthey had been laid off need not have been looking for work to be classified as unemployed.\n\nDerived from the [Local Area Unemployment Statistics (LAUS)](https://www.bls.gov/lau/) program, \na federal-state cooperative effort overseen by the Bureau of Labor Statistics (BLS). \nThe LAUS program produces monthly and annual employment, unemployment, and labor force data for census regions and divisions,\nstates, counties, metropolitan areas, and many cities and towns.\n\nFor the most up-to-date LAUS data:\n1. **Monthly and Annual Data Downloads**:\n- Visit the [LAUS Data Tools](https://www.bls.gov/lau/data.htm) page for [monthly](https://www.bls.gov/lau/tables.htm#mcounty) \nand [annual](https://www.bls.gov/lau/tables.htm#cntyaa) county data.\n2. **BLS Public Data API**:\n- The BLS provides an API for developers to access various datasets, including LAUS data.\n- To use the API for LAUS data, refer to the [LAUS Series ID Formats](https://www.bls.gov/help/hlpforma.htm#LA) to construct your query.\n- API documentation and examples are available on the BLS Developers page.\n\nWhen using BLS public data API and datasets, users should adhere to the [BLS Terms of Service](https://www.bls.gov/developers/termsOfService.htm).",
       "licenses": [

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "3.1.0",
-  "created": "2025-07-01T22:14:24.642423+00:00",
+  "created": "2025-07-03T22:03:32.424280+00:00",
   "resources": [
     {
       "name": "icon_7zip",
@@ -2135,7 +2135,7 @@
       }
     },
     {
-      "name": "londonBoroughs",
+      "name": "london_boroughs",
       "type": "json",
       "description": "Boundaries of London boroughs reprojected and simplified from `London_Borough_Excluding_MHW` shapefile. \nOriginal data \"contains National Statistics data © Crown copyright and database right (2015)\" \nand \"Contains Ordnance Survey data © Crown copyright and database right [2015].",
       "licenses": [
@@ -2159,7 +2159,7 @@
       "bytes": 14732
     },
     {
-      "name": "londonCentroids",
+      "name": "london_centroids",
       "type": "table",
       "description": "Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/d3-geo/math#geoCentroid).",
       "licenses": [
@@ -2204,7 +2204,7 @@
       }
     },
     {
-      "name": "londonTubeLines",
+      "name": "london_tube_lines",
       "type": "json",
       "description": "A [topologically-encoded](https://github.com/topojson/topojson) representation of select London Underground rail lines, derived from OpenStreetMap\ndata. These 394 LineString geometries, encoded using 406 arcs, depict transport paths between stations with stations marked as nodes\nalong the lines. Originally transformed from a GeoJSON intermediary `tfl_lines.json` into TopoJSON format, this network configuration \nreflects the system as of February 4, 2018, and may not incorporate subsequent modifications or expansions.\n",
       "licenses": [

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`3.1.0` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2025-03-31 17:24:58 [UTC]
+`3.1.0` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2025-07-01 22:14:24 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 
@@ -19,7 +19,7 @@ is a reference starting point only and is provided without any warranty of accur
 | vega-datasets contributors | https://github.com/vega/vega-datasets/graphs/contributors |
 
 # resources
-## `7zip.png`
+## `icon_7zip`
 ### path
 7zip.png
 ### description
@@ -32,7 +32,7 @@ Application icon from open-source software project. Used in [Image-based Scatter
 | title                             | path                              |
 |:----------------------------------|:----------------------------------|
 | GNU Lesser General Public License | https://www.7-zip.org/license.txt |
-## `airports.csv`
+## `airports`
 ### path
 airports.csv
 ### description
@@ -58,7 +58,7 @@ coordinates), identification codes, name, city, state, and country.
 | name       | title                                |
 |:-----------|:-------------------------------------|
 | other-open | https://www.usa.gov/government-works |
-## `annual-precip.json`
+## `annual_precip`
 ### path
 annual-precip.json
 ### description
@@ -71,7 +71,7 @@ A raster grid of global annual precipitation for the year 2016 at a resolution 1
 | title         | path                                |
 |:--------------|:------------------------------------|
 | Public Domain | https://www.weather.gov/disclaimer/ |
-## `anscombe.json`
+## `anscombe`
 ### path
 anscombe.json
 ### description
@@ -99,7 +99,7 @@ statistical analysis should combine both numerical calculations and graphical ex
 |:------------------------------------------------------------------------------------------------|:--------------------------------------------------------|
 | Anscombe's quartet (Wikipedia)                                                                  | https://en.wikipedia.org/wiki/Anscombe%27s_quartet#Data |
 | Anscombe, F. J. (1973). Graphs in Statistical Analysis. The American Statistician, 27(1):17-21. | https://www.jstor.org/stable/2682899                    |
-## `barley.json`
+## `barley`
 ### path
 barley.json
 ### description
@@ -130,7 +130,7 @@ Since then it has been used to demonstrate new visualization techniques, includi
 | name                                                                                        |
 |:--------------------------------------------------------------------------------------------|
 | Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified |
-## `birdstrikes.csv`
+## `birdstrikes`
 ### path
 birdstrikes.csv
 ### description
@@ -161,7 +161,7 @@ Records of reported wildlife strikes received by the U.S. FAA
 | title                   | path                                      |
 |:------------------------|:------------------------------------------|
 | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
-## `budget.json`
+## `budget`
 ### path
 budget.json
 ### description
@@ -250,7 +250,7 @@ Historical and forecasted federal revenue/receipts produced in 2016 by the U.S. 
 | title                   | path                                      |
 |:------------------------|:------------------------------------------|
 | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
-## `budgets.json`
+## `budgets`
 ### path
 budgets.json
 ### description
@@ -273,7 +273,7 @@ representing deficits (reaching a particularly large value of -$1.78 trillion du
 | title                   | path                                      |
 |:------------------------|:------------------------------------------|
 | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
-## `burtin.json`
+## `burtin`
 ### path
 burtin.json
 ### description
@@ -326,7 +326,7 @@ reads as follows:
 | title                      | path                                 |
 |:---------------------------|:-------------------------------------|
 | BSD License (via Protovis) | https://mbostock.github.io/protovis/ |
-## `cars.json`
+## `cars`
 ### path
 cars.json
 ### description
@@ -352,7 +352,7 @@ Collection of car specifications and performance metrics from various automobile
 | title                                                                         | path                                       |
 |:------------------------------------------------------------------------------|:-------------------------------------------|
 | The original was distributed in 1982 for educational and scientific purposes. | http://lib.stat.cmu.edu/datasets/cars.desc |
-## `co2-concentration.csv`
+## `co2_concentration`
 ### path
 co2-concentration.csv
 ### description
@@ -382,7 +382,7 @@ Only includes rows with valid data.
 | title                            | path                                         |
 |:---------------------------------|:---------------------------------------------|
 | Creative Commons Attribution 4.0 | https://creativecommons.org/licenses/by/4.0/ |
-## `countries.json`
+## `countries`
 ### path
 countries.json
 ### description
@@ -412,7 +412,7 @@ aims to "show people the big picture" rather than support detailed numeric analy
 | title                                          | path                                     |
 |:-----------------------------------------------|:-----------------------------------------|
 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
-## `crimea.json`
+## `crimea`
 ### path
 crimea.json
 ### description
@@ -448,7 +448,7 @@ the dramatic impact of sanitary reforms, particularly in reducing preventable de
 | title                                                               | path                                                                                 |
 |:--------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
 | Harvard Library - Digitized Content Copyright & Viewer Terms of Use | https://library.harvard.edu/privacy-terms-use-copyright-information#digitizedcontent |
-## `disasters.csv`
+## `disasters`
 ### path
 disasters.csv
 ### description
@@ -473,7 +473,7 @@ calculating derived indicators, and adapting metadata. Deaths are reported as ab
 |:------------------------------------------------|:----------------------------------------------|
 | EM-DAT terms of use                             | https://doc.emdat.be/docs/legal/terms-of-use/ |
 | Creative Commons BY license (Our World in Data) | https://creativecommons.org/licenses/by/4.0/  |
-## `driving.json`
+## `driving`
 ### path
 driving.json
 ### description
@@ -495,7 +495,7 @@ the cheap gas era, Arab oil embargo, energy crisis, record low prices, and the
 | title                                                                                                                     | path                                                                                      |
 |:--------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------|
 | New York Times (citing U.S. Energy Information Administration, Federal Highway Administration, and Brookings Institution) | https://archive.nytimes.com/www.nytimes.com/imagepages/2010/05/02/business/02metrics.html |
-## `earthquakes.json`
+## `earthquakes`
 ### path
 earthquakes.json
 ### description
@@ -510,7 +510,7 @@ USGS Earthquake Hazards Program from January 31 to February 7, 2018 (UTC).
 | title              | path                                                                              |
 |:-------------------|:----------------------------------------------------------------------------------|
 | U.S. Public Domain | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
-## `ffox.png`
+## `ffox`
 ### path
 ffox.png
 ### description
@@ -523,7 +523,7 @@ Application icon from open-source software project. Used in [Image-based Scatter
 | title                     | path                                                        |
 |:--------------------------|:------------------------------------------------------------|
 | Mozilla Trademark License | https://www.mozilla.org/en-US/foundation/trademarks/policy/ |
-## `flare-dependencies.json`
+## `flare_dependencies`
 ### path
 flare-dependencies.json
 ### description
@@ -534,7 +534,7 @@ Indicates, with `flare.json`, relationships among classes in a software hierarch
 |:-------|:--------|
 | source | integer |
 | target | integer |
-## `flare.json`
+## `flare`
 ### path
 flare.json
 ### description
@@ -545,7 +545,7 @@ Indicates, with `flare-dependencies.json`, relationships among classes in a soft
 |:-------|:--------|
 | id     | integer |
 | name   | string  |
-## `flights-10k.json`
+## `flights_10k`
 ### path
 flights-10k.json
 ### description
@@ -570,7 +570,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-200k.arrow`
+## `flights_200k_arrow`
 ### path
 flights-200k.arrow
 ### description
@@ -593,7 +593,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-200k.json`
+## `flights_200k_json`
 ### path
 flights-200k.json
 ### description
@@ -616,7 +616,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-20k.json`
+## `flights_20k`
 ### path
 flights-20k.json
 ### description
@@ -641,7 +641,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                     |
 |:-----------|:-----------------------------------------------------------------------|:------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-2k.json`
+## `flights_2k`
 ### path
 flights-2k.json
 ### description
@@ -666,7 +666,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-3m.parquet`
+## `flights_3m`
 ### path
 flights-3m.parquet
 ### description
@@ -691,7 +691,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-5k.json`
+## `flights_5k`
 ### path
 flights-5k.json
 ### description
@@ -716,7 +716,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 | name       | path                                                                   | title                                                                                          |
 |:-----------|:-----------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|
 | other-open | https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-234 | Data Collected Under U.S. DOT Regulatory Requirements - License Terms Not Explicitly Specified |
-## `flights-airport.csv`
+## `flights_airport`
 ### path
 flights-airport.csv
 ### description
@@ -738,7 +738,7 @@ a destination airport, and the count of flights along this route.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `football.json`
+## `football`
 ### path
 football.json
 ### description
@@ -763,7 +763,7 @@ chosen divisions over the time period.
 | path                                                                     |
 |:-------------------------------------------------------------------------|
 | https://github.com/openfootball/football.json?tab=readme-ov-file#license |
-## `gapminder-health-income.csv`
+## `gapminder_health_income`
 ### path
 gapminder-health-income.csv
 ### description
@@ -793,7 +793,7 @@ Gapminder (v30, 2023) defines per-capita income as follows:
 | title                                          | path                                     |
 |:-----------------------------------------------|:-----------------------------------------|
 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
-## `gapminder.json`
+## `gapminder`
 ### path
 gapminder.json
 ### description
@@ -843,7 +843,7 @@ Notes:
 | title                                          | path                                     |
 |:-----------------------------------------------|:-----------------------------------------|
 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
-## `gimp.png`
+## `gimp`
 ### path
 gimp.png
 ### description
@@ -856,7 +856,7 @@ Application icon from open-source software project. Used in [Image-based Scatter
 | path                                                                                       |
 |:-------------------------------------------------------------------------------------------|
 | https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it |
-## `github.csv`
+## `github`
 ### path
 github.csv
 ### description
@@ -877,7 +877,7 @@ in a GitHub-style punchcard visualization format.
 | path                                                            |
 |:----------------------------------------------------------------|
 | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
-## `global-temp.csv`
+## `global_temp`
 ### path
 global-temp.csv
 ### description
@@ -896,7 +896,7 @@ Combined Land-Surface Air and Sea-Surface Water Temperature Anomalies (Land-Ocea
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `income.json`
+## `income`
 ### path
 income.json
 ### description
@@ -924,7 +924,7 @@ but is not endorsed or certified by the Census Bureau.
 | title                                   | path                                                               | name                       |
 |:----------------------------------------|:-------------------------------------------------------------------|:---------------------------|
 | U.S. Census Bureau API Terms of Service | https://www.census.gov/data/developers/about/terms-of-service.html | Census Bureau Terms of Use |
-## `iowa-electricity.csv`
+## `iowa_electricity`
 ### path
 iowa-electricity.csv
 ### description
@@ -945,7 +945,7 @@ Useful for illustrating stacked area charts. Demonstrates dramatic increase in w
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `jobs.json`
+## `jobs`
 ### path
 jobs.json
 ### description
@@ -986,7 +986,7 @@ Steven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. 
 | title              | path                              |
 |:-------------------|:----------------------------------|
 | IPUMS Terms of Use | https://www.ipums.org/about/terms |
-## `la-riots.csv`
+## `la_riots`
 ### path
 la-riots.csv
 ### description
@@ -1012,7 +1012,7 @@ Originally compiled and published by the Los Angeles Times Data Desk.
 | title                                        | path                                             |
 |:---------------------------------------------|:-------------------------------------------------|
 | LA Riots Deaths, Los Angeles Times Data Desk | http://spreadsheets.latimes.com/la-riots-deaths/ |
-## `londonboroughs.json`
+## `londonBoroughs`
 ### path
 londonBoroughs.json
 ### description
@@ -1027,7 +1027,7 @@ and "Contains Ordnance Survey data © Crown copyright and database right [2015].
 | title                      | path                                                                       |
 |:---------------------------|:---------------------------------------------------------------------------|
 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-## `londoncentroids.json`
+## `londonCentroids`
 ### path
 londonCentroids.json
 ### description
@@ -1047,7 +1047,7 @@ Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/
 | title                      | path                                                                       |
 |:---------------------------|:---------------------------------------------------------------------------|
 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-## `londontubelines.json`
+## `londonTubeLines`
 ### path
 londonTubeLines.json
 ### description
@@ -1064,7 +1064,7 @@ reflects the system as of February 4, 2018, and may not incorporate subsequent m
 | title                                          | path                                       |
 |:-----------------------------------------------|:-------------------------------------------|
 | Open Data Commons Open Database License (ODbL) | https://opendatacommons.org/licenses/odbl/ |
-## `lookup_groups.csv`
+## `lookup_groups`
 ### path
 lookup_groups.csv
 ### description
@@ -1084,7 +1084,7 @@ mapping people to groups. Used to [demonstrate](https://vega.github.io/vega-lite
 | path                                                            |
 |:----------------------------------------------------------------|
 | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
-## `lookup_people.csv`
+## `lookup_people`
 ### path
 lookup_people.csv
 ### description
@@ -1106,7 +1106,7 @@ to [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup`
 | path                                                            |
 |:----------------------------------------------------------------|
 | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
-## `miserables.json`
+## `miserables`
 ### path
 miserables.json
 ### description
@@ -1123,7 +1123,7 @@ coappearances.
 | path                                      |
 |:------------------------------------------|
 | https://websites.umich.edu/~mejn/netdata/ |
-## `monarchs.json`
+## `monarchs`
 ### path
 monarchs.json
 ### description
@@ -1162,7 +1162,7 @@ Source data has been verified against the kings & queens and interregnum pages o
 | title                             | path                                                                       |
 |:----------------------------------|:---------------------------------------------------------------------------|
 | Open Government Licence v3.0 (UK) | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-## `movies.json`
+## `movies`
 ### path
 movies.json
 ### description
@@ -1189,7 +1189,7 @@ resource for developing data cleaning and validation skills in real-world analys
 | Rotten Tomatoes Rating | integer |
 | IMDB Rating            | number  |
 | IMDB Votes             | integer |
-## `normal-2d.json`
+## `normal_2d`
 ### path
 normal-2d.json
 ### description
@@ -1217,7 +1217,7 @@ A contrast to uniformly distributed data in `uniform-2d.json`
 | path                                                            |
 |:----------------------------------------------------------------|
 | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
-## `obesity.json`
+## `obesity`
 ### path
 obesity.json
 ### description
@@ -1238,7 +1238,7 @@ Originally [Behavioral Risk Factor Surveillance System (BRFSS)](https://www.cdc.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `ohlc.json`
+## `ohlc`
 ### path
 ohlc.json
 ### description
@@ -1263,7 +1263,7 @@ The precise methodology used to derive the signal and calculate the ret columns 
 |:---------------------------|:----------------------------------------------------------------|
 | Yahoo Finance VIX Data     | https://finance.yahoo.com/chart/%5EVIX                          |
 | CBOE - VIX Historical Data | https://www.cboe.com/tradable_products/vix/vix_historical_data/ |
-## `penguins.json`
+## `penguins`
 ### path
 penguins.json
 ### description
@@ -1293,7 +1293,7 @@ variations between species and sexual dimorphism in Antarctic penguins.
 | name              | path                                                                        |
 |:------------------|:----------------------------------------------------------------------------|
 | CC0 1.0 Universal | https://github.com/allisonhorst/palmerpenguins?tab=CC0-1.0-1-ov-file#readme |
-## `platformer-terrain.json`
+## `platformer_terrain`
 ### path
 platformer-terrain.json
 ### description
@@ -1314,7 +1314,7 @@ Assets from the video game Celeste. Added in [#376](https://github.com/vega/vega
 | title        | path                        |
 |:-------------|:----------------------------|
 | Celeste Game | http://www.celestegame.com/ |
-## `political-contributions.json`
+## `political_contributions`
 ### path
 political-contributions.json
 ### description
@@ -1374,7 +1374,7 @@ Additionally, the FEC's Github [repository](https://github.com/fecgov/FEC) state
 | title                               | path                                               |
 |:------------------------------------|:---------------------------------------------------|
 | Creative Commons Zero 1.0 Universal | https://creativecommons.org/publicdomain/zero/1.0/ |
-## `population.json`
+## `population`
 ### path
 population.json
 ### description
@@ -1405,7 +1405,7 @@ http://doi.org/10.18128/D010.V6.0
 | title              | path                              |
 |:-------------------|:----------------------------------|
 | IPUMS Terms of Use | https://www.ipums.org/about/terms |
-## `population_engineers_hurricanes.csv`
+## `population_engineers_hurricanes`
 ### path
 population_engineers_hurricanes.csv
 ### description
@@ -1430,7 +1430,7 @@ Per-state population, number of engineers, and hurricanes. Used in Vega-Lite exa
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `seattle-weather-hourly-normals.csv`
+## `seattle_weather_hourly_normals`
 ### path
 seattle-weather-hourly-normals.csv
 ### description
@@ -1455,7 +1455,7 @@ and updated the format to be easier to parse.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `seattle-weather.csv`
+## `seattle_weather`
 ### path
 seattle-weather.csv
 ### description
@@ -1480,7 +1480,7 @@ This data is intended for instructional purposes.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `sp500-2000.csv`
+## `sp500_2000`
 ### path
 sp500-2000.csv
 ### description
@@ -1500,7 +1500,7 @@ S&amp;P 500 index values from 2000 to 2020.
 | title         | path                                            |
 |:--------------|:------------------------------------------------|
 | Yahoo Finance | https://finance.yahoo.com/quote/%5EDJI/history/ |
-## `sp500.csv`
+## `sp500`
 ### path
 sp500.csv
 ### description
@@ -1514,7 +1514,7 @@ the dot-com bubble burst (2000-2002), the mid-2000s bull market, and the 2008 fi
 |:-------|:-------|:-------------------------------------------------------|
 | date   | string | Date of monthly observation in the format 'MMM D YYYY' |
 | price  | number | Closing price of the S&P 500 index for the given month |
-## `species.csv`
+## `species`
 ### path
 species.csv
 ### description
@@ -1551,7 +1551,7 @@ for zonal statistics.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `stocks.csv`
+## `stocks`
 ### path
 stocks.csv
 ### description
@@ -1563,7 +1563,7 @@ Monthly stock prices for five companies from 2000 to 2010.
 | symbol | string |
 | date   | string |
 | price  | number |
-## `udistrict.json`
+## `udistrict`
 ### path
 udistrict.json
 ### description
@@ -1577,7 +1577,7 @@ using this dataset states that it originally appeared in Alaska Airlines Beyond 
 |:-------|:-------|
 | key    | string |
 | lat    | number |
-## `unemployment-across-industries.json`
+## `unemployment_across_industries`
 ### path
 unemployment-across-industries.json
 ### description
@@ -1615,7 +1615,7 @@ See full BLS [terms of service](https://www.bls.gov/developers/termsOfService.ht
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `unemployment.tsv`
+## `unemployment`
 ### path
 unemployment.tsv
 ### description
@@ -1660,7 +1660,7 @@ When using BLS public data API and datasets, users should adhere to the [BLS Ter
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `uniform-2d.json`
+## `uniform_2d`
 ### path
 uniform-2d.json
 ### description
@@ -1683,7 +1683,7 @@ A contrast to normally distributed data in `normal-2d.json`.
 | path                                                            |
 |:----------------------------------------------------------------|
 | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
-## `us-10m.json`
+## `us_10m`
 ### path
 us-10m.json
 ### description
@@ -1701,7 +1701,7 @@ in turn is a redistribution of the Census Bureau's cartographic boundary shapefi
 | title                         | path                                                        |
 |:------------------------------|:------------------------------------------------------------|
 | TopoJSON US Atlas ISC License | https://github.com/topojson/us-atlas/blob/master/LICENSE.md |
-## `us-employment.csv`
+## `us_employment`
 ### path
 us-employment.csv
 ### description
@@ -1757,7 +1757,7 @@ negative and positive values.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `us-state-capitals.json`
+## `us_state_capitals`
 ### path
 us-state-capitals.json
 ### description
@@ -1790,7 +1790,7 @@ According to [USGS]((https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-s
 |:------------------------|:----------------------------------------------------------------------------------|
 | U.S. Public Domain      | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
 | U.S. Government Dataset | https://www.usa.gov/government-works                                              |
-## `volcano.json`
+## `volcano`
 ### path
 volcano.json
 ### description
@@ -1802,7 +1802,7 @@ Should not be regarded as accurate.
 | title      | path                                                                       |
 |:-----------|:---------------------------------------------------------------------------|
 | R Datasets | https://stat.ethz.ch/R-manual/R-patched/library/datasets/html/volcano.html |
-## `weather.csv`
+## `weather`
 ### path
 weather.csv
 ### description
@@ -1829,7 +1829,7 @@ Intended for instructional purposes.
 | title                   | path                                 |
 |:------------------------|:-------------------------------------|
 | U.S. Government Dataset | https://www.usa.gov/government-works |
-## `weekly-weather.json`
+## `weekly_weather`
 ### path
 weekly-weather.json
 ### description
@@ -1838,7 +1838,7 @@ Instructional dataset showing actual and predicted temperature data.
 > [!IMPORTANT]
 > Named `weather.json` in previous versions (`v1.4.0` - `v2.11.0`).
 
-## `wheat.json`
+## `wheat`
 ### path
 wheat.json
 ### description
@@ -1864,7 +1864,7 @@ He intended to demonstrate that:
 | title         | path                                             |
 |:--------------|:-------------------------------------------------|
 | Public Domain | https://commons.wikimedia.org/wiki/Public_domain |
-## `windvectors.csv`
+## `windvectors`
 ### path
 windvectors.csv
 ### description
@@ -1878,7 +1878,7 @@ Simulated wind patterns over northwestern Europe.
 | dir       | integer |
 | dirCat    | integer |
 | speed     | number  |
-## `world-110m.json`
+## `world_110m`
 ### path
 world-110m.json
 ### description
@@ -1901,7 +1901,7 @@ resource for creating web-based world maps where precise boundary detail isn't r
 |:---------------------------------|:---------------------------------------------------------------|
 | TopoJSON World Atlas ISC License | https://github.com/topojson/world-atlas/blob/master/LICENSE.md |
 | Natural Earth Data Public Domain | https://www.naturalearthdata.com/about/terms-of-use/           |
-## `zipcodes.csv`
+## `zipcodes`
 ### path
 zipcodes.csv
 ### description

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`3.1.0` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2025-07-01 22:14:24 [UTC]
+`3.1.0` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2025-07-03 22:03:32 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 
@@ -1012,7 +1012,7 @@ Originally compiled and published by the Los Angeles Times Data Desk.
 | title                                        | path                                             |
 |:---------------------------------------------|:-------------------------------------------------|
 | LA Riots Deaths, Los Angeles Times Data Desk | http://spreadsheets.latimes.com/la-riots-deaths/ |
-## `londonBoroughs`
+## `london_boroughs`
 ### path
 londonBoroughs.json
 ### description
@@ -1027,7 +1027,7 @@ and "Contains Ordnance Survey data © Crown copyright and database right [2015].
 | title                      | path                                                                       |
 |:---------------------------|:---------------------------------------------------------------------------|
 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-## `londonCentroids`
+## `london_centroids`
 ### path
 londonCentroids.json
 ### description
@@ -1047,7 +1047,7 @@ Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/
 | title                      | path                                                                       |
 |:---------------------------|:---------------------------------------------------------------------------|
 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-## `londonTubeLines`
+## `london_tube_lines`
 ### path
 londonTubeLines.json
 ### description

--- a/scripts/species.py
+++ b/scripts/species.py
@@ -655,7 +655,7 @@ class HabitatDataProcessor:
         for tif_file in tif_files:
             # Extract species code from filename
             stem: str = tif_file.stem
-            species: SpeciesCode = stem.split("_")[0]
+            species: SpeciesCode = stem.split("_", 1)[0]
 
             # Determine column names based on number of raster files
             if len(tif_files) > 1:


### PR DESCRIPTION
This PR updates dataset names in `datapackage.json` to be UAX-31 compliant, making them valid Python identifiers. The changes only affect the `name` fields while keeping the `path` fields unchanged.

I'm not sure if this is sufficient to close #695, but otherwise it can serve as a starting point for a discussion towards closing the related issue.

## Changes
- Converted hyphens to underscores in names
- Removed file extensions (`.json`, `.csv`, `.png`) from all dataset names
- Added `icon_` prefix to image files
- Ensured all names are valid Python identifiers

### Examples of Changes
```diff
- "name": "7zip.png"
+ "name": "icon_7zip"

- "name": "annual-precip.json"
+ "name": "annual_precip"
```

Only oddities are related to extension `arrow` and `parquet`:
```diff
- "name": "flights_200k.arrow"
+ "name": "flights_200k_arrow"

- "name": "flights_200k.json"
+ "name": "flights_200k"

- "name": "flights_3m.parquet"
+ "name": "flights_3m_parquet"
```

Regarding `flights_200k`, there is a `arrow` and `json` variant. Therefor opt to add `_arrow` to the `name` for the `arrow` variant, since it is not a common file type, same rationale was applied for the `parquet` file of `flights_3m`.

## Rationale
- Makes dataset names valid Python identifiers
- Improves consistency in naming convention
- Keep file paths unchanged
- Follows UAX-31 standard for general-purpose identifiers

## Testing
- Verified all new names are valid Python identifiers
- Confirmed all `path` fields remain unchanged
- Checked that all names are unique

## Checklist
- [x] All dataset names are UAX-31 compliant
- [x] File paths remain unchanged
- [x] Image files have appropriate prefixes
- [x] No duplicate names