### PR TITLE
Style: Fix PLC0207 linting error in species.py (related to #705)

### DIFF
--- a/scripts/species.py
+++ b/scripts/species.py
@@ -655,7 +655,7 @@ class HabitatDataProcessor:
         for tif_file in tif_files:
             # Extract species code from filename
             stem: str = tif_file.stem
-            species: SpeciesCode = stem.split("_")[0]
+            species: SpeciesCode = stem.split("_", 1)[0]
 
             # Determine column names based on number of raster files
             if len(tif_files) > 1:


### PR DESCRIPTION
This PR resolves a Ruff linting error (`PLC0207`) in `scripts/species.py` by applying the `maxsplit=1` optimization for string splitting during species code extraction. Issue #705 raises questions about linting stability and version pinning that should be addressed separately.

Relates to #705