### PR TITLE
ci: Use uv run for dev tools to ensure locked versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ jobs:
           enable-cache: true
 
       - name: Format toml
-        run: uvx taplo fmt --check --diff
+        run: uv run taplo fmt --check --diff
 
       - name: Format and lint (python)
         run: |
-          uvx ruff check
-          uvx ruff format --check
+          uv run ruff check
+          uv run ruff format --check
 
       - name: Install Node dependencies
         run: npm ci

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,4 +1,8 @@
 #:schema taplo://taplo.toml
+
+exclude = [".venv/**/*.toml"]
+include = ["**/taplo.toml", "pyproject.toml"]
+
 [formatting]
 align_entries       = true
 allowed_blank_lines = 1


### PR DESCRIPTION
Addresses issue #705.

This PR updates the CI workflow in `.github/workflows/test.yml` to use `uv run` instead of `uvx` for executing our linting and formatting tools (`ruff` and `taplo`).

**Why this change?**

* **Ensures Locked Versions:** This change guarantees that our CI pipeline uses the exact versions of `ruff` and `taplo` that are pinned in our `uv.lock` file. Previously, `uvx` might not have strictly adhered to these locked versions for the tools themselves.
* **Reproducibility & Consistency:** By using `uv run`, we align the CI environment more closely with local development setups when using `uv`. This command activates the project's managed environment, ensuring that the same tool versions are used everywhere, which is crucial for reproducible builds.
* **Best Practice:** `uv run` is the recommended command for executing tools that are part of the project's dependencies (including dev dependencies). The `uv` documentation [states](https://docs.astral.sh/uv/guides/tools/#running-tools):

> If you are running a tool in a [project](https://docs.astral.sh/uv/concepts/projects/) and the tool requires that your project is installed, e.g., when using pytest or mypy, you'll want to use [uv run](https://docs.astral.sh/uv/guides/projects/#running-commands) instead of uvx. Otherwise, the tool will be run in a virtual environment that is isolated from your project.

This approach should resolve the recent CI instability potentially caused by differing linter/formatter versions and lead to more predictable workflow runs.

Thanks to @domoritz for flagging the issue and @dangotbanned for the initial investigation into `uvx` vs `uv run` behavior.