### PR TITLE
fix: correct github clone URL in contributing guidelines 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ npm run build
 
 1. Fork and clone the repository:
    ```
-   git clone https://github.com/YOUR-USERNAME/vega-datasets.git
+   git clone https://github.com/vega/vega-datasets.git
    cd vega-datasets
    npm install
    ```


### PR DESCRIPTION
consistent with vega-lite [CONTRIBUTING.md](https://github.com/vega/vega-lite/blob/main/CONTRIBUTING.md)


> 2. Clone this repository and cd into your local clone of the repository, and install all the npm dependencies:
> 
> ```sh
> git clone https://github.com/vega/vega-lite.git
> cd vega-lite
> npm install
> ```