### PR TITLE
feat: improve Data Package metadata compliance with CKAN licenses and field schemas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,20 +166,21 @@ npm run build
 
 ### Code Quality Checks
 
-Run these checks before submitting:
+Run these checks before submitting (using `uv run` ensures correct tool versions from `uv.lock` are used):
 
 ```bash
 # TOML formatting
-uvx taplo fmt --check --diff
+uv run taplo fmt --check --diff
 
 # Python linting and formatting
-uvx ruff check
-uvx ruff format --check
+uv run ruff check
+uv run ruff format --check
+```
 
 To automatically fix issues:
 ```bash
-uvx taplo fmt
-uvx ruff format
+uv run taplo fmt
+uv run ruff format
 ```
 
 ## Contributing Process
@@ -193,7 +194,7 @@ uvx ruff format
 
 3. Run checks and build:
    ```
-   uvx taplo fmt --check --diff && uvx ruff check && uvx ruff format --check
+   uv run taplo fmt --check --diff && uv run ruff check && uv run ruff format --check
    npm run build
    ```
 

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -464,7 +464,13 @@ description = "Indicates, with `flare.json`, relationships among classes in a so
 
 [[resources]] # Path: flare.json
 path        = "flare.json"
-description = "Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy."
+description = """Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy.
+
+Represents a tree structure where nodes have different fields depending on their role:
+- Root node: only `id` and `name`
+- Branch nodes: `id`, `name`, and `parent`
+- Leaf nodes: `id`, `name`, `parent`, and `size`
+"""
 
 [resources.schema]
 [[resources.schema.fields]]
@@ -587,9 +593,9 @@ title = "Data Collected Under U.S. DOT Regulatory Requirements - License Terms N
 
 [[resources]] # Path: flights-3m.parquet
 path = "flights-3m.parquet"
-description = """Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics.
-Collected under regulatory reporting requirements (14 CFR Part 234), which mandate
-that qualifying airlines report on-time performance data to BTS. Transformed using
+description = """Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics. 
+Collected under regulatory reporting requirements (14 CFR Part 234), which mandate 
+that qualifying airlines report on-time performance data to BTS. Transformed using 
 `/scripts/flights.py`"""
 
 [resources.schema]
@@ -631,20 +637,17 @@ title = "Data Collected Under U.S. DOT Regulatory Requirements - License Terms N
 
 [[resources]] # Path: flights-airport.csv
 path = "flights-airport.csv"
-description = """Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id), 
+description = """Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id),
 a destination airport, and the count of flights along this route."""
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
+path  = "https://www.transtats.bts.gov/DL_SelectFields.asp?gnoyr_VQ=FGJ&QO_fu146_anzr=b0-gvzr"
 
 [[resources.licenses]]
 name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
-
-[[resources.sources]]
-title = "U.S. Bureau of Transportation Statistics"
-path  = "https://www.transtats.bts.gov/DL_SelectFields.asp?gnoyr_VQ=FGJ&QO_fu146_anzr=b0-gvzr"
 
 [[resources]] # Path: football.json
 path = "football.json"
@@ -1089,9 +1092,13 @@ path  = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version
 
 [[resources]] # Path: movies.json
 path = "movies.json"
-description = """A collection of films and their performance metrics, including box office earnings, budgets, 
-and audience ratings. Contains known data quality issues and intentional errors, serving as a teaching 
-resource for developing data cleaning and validation skills in real-world analysis workflows."""
+description = """A collection of films and their performance metrics, including box office earnings, budgets,
+and audience ratings. Contains known data quality issues typical of real-world datasets:
+- Some movie titles with numeric names (1776, 2012, 300, etc.) are stored as JSON numbers rather than strings
+- Release dates use 'MMM DD YYYY' format rather than ISO 8601
+
+These characteristics make it suitable as a teaching resource for developing data cleaning
+and validation skills in real-world analysis workflows."""
 
 [resources.schema]
 [[resources.schema.fields]]

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -220,6 +220,11 @@ path  = "https://mbostock.github.io/protovis/"
 path        = "cars.json"
 description = "Collection of car specifications and performance metrics from various automobile manufacturers."
 
+[resources.schema]
+[[resources.schema.fields]]
+name = "Miles_per_Gallon"
+type = "number"
+
 [[resources.sources]]
 title = "StatLib Datasets Archive"
 path  = "http://lib.stat.cmu.edu/datasets/"
@@ -460,6 +465,27 @@ description = "Indicates, with `flare.json`, relationships among classes in a so
 [[resources]] # Path: flare.json
 path        = "flare.json"
 description = "Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy."
+
+[resources.schema]
+[[resources.schema.fields]]
+name        = "id"
+type        = "integer"
+description = "Unique identifier for the node"
+
+[[resources.schema.fields]]
+name        = "name"
+type        = "string"
+description = "Name of the node in the hierarchy"
+
+[[resources.schema.fields]]
+name        = "parent"
+type        = "integer"
+description = "ID of parent node (absent for root node)"
+
+[[resources.schema.fields]]
+name        = "size"
+type        = "integer"
+description = "Size value (only present on leaf nodes)"
 
 [[resources]] # Path: flights-10k.json
 path = "flights-10k.json"
@@ -1044,6 +1070,7 @@ description = "A zero-based sequential number assigned to each entry, representi
 
 [[resources.schema.fields]]
 name        = "commonwealth"
+type        = "boolean"
 description = "A Boolean flag (true) for the period from 1649 to 1660. This field is omitted for all other entries"
 
 [[resources.sources]]

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -812,6 +812,7 @@ description = "Simulated hourly commit counts"
 
 [[resources.sources]]
 title = """Generated using `/scripts/github.py`."""
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/github.py"
 
 [[resources.licenses]]
 name  = "BSD-3-Clause"

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -460,11 +460,25 @@ path  = "https://www.mozilla.org/en-US/foundation/trademarks/policy/"
 
 [[resources]] # Path: flare-dependencies.json
 path        = "flare-dependencies.json"
-description = "Indicates, with `flare.json`, relationships among classes in a software hierarchy."
+description = """Network of class dependencies for the Flare visualization library. Each entry
+represents a directed edge where the `source` class depends on (imports) the `target` class.
+IDs correspond to those in `flare.json`."""
+
+[resources.schema]
+[[resources.schema.fields]]
+name        = "source"
+type        = "integer"
+description = "ID of the class that has the dependency (the importer)"
+
+[[resources.schema.fields]]
+name        = "target"
+type        = "integer"
+description = "ID of the class being depended upon (the imported)"
 
 [[resources]] # Path: flare.json
 path        = "flare.json"
-description = """Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy.
+description = """Class hierarchy of the Flare visualization library. Used with `flare-dependencies.json`
+to represent the complete package/class structure.
 
 Represents a tree structure where nodes have different fields depending on their role:
 - Root node: only `id` and `name`

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -23,6 +23,7 @@ title = "7-Zip"
 path  = "https://www.7-zip.org/"
 
 [[resources.licenses]]
+name  = "LGPL-2.1"
 title = "GNU Lesser General Public License"
 path  = "https://www.7-zip.org/license.txt"
 
@@ -49,6 +50,7 @@ title = "Climate Forecast System Version 2"
 path  = "https://www.cpc.ncep.noaa.gov/products/people/wwang/cfsv2_fcst_history/"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "Public Domain"
 path  = "https://www.weather.gov/disclaimer/"
 
@@ -99,7 +101,8 @@ title = "Wiebe, G. A., Reinbach-Welch, L., Cowan, P. R. (1940). Yields of Barley
 path  = "https://books.google.com/books?id=OUfxLocnpKkC&pg=PA19"
 
 [[resources.licenses]]
-name = "Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified"
+name  = "notspecified"
+title = "Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified"
 
 [[resources]] # Path: birdstrikes.csv
 path        = "birdstrikes.csv"
@@ -110,6 +113,7 @@ title = "FAA Wildlife Strike Database"
 path  = "http://wildlife.faa.gov"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://resources.data.gov/open-licenses/"
 
@@ -122,6 +126,7 @@ title = "Office of Management and Budget - Budget FY 2016 - Receipts"
 path  = "https://www.govinfo.gov/app/details/BUDGET-2016-DB/BUDGET-2016-DB-3"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://resources.data.gov/open-licenses/"
 
@@ -151,6 +156,7 @@ title = "Office of Management and Budget"
 path  = "https://www.whitehouse.gov/omb/"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://resources.data.gov/open-licenses/"
 
@@ -206,6 +212,7 @@ title = "Protovis Antibiotics Example"
 path  = "https://mbostock.github.io/protovis/ex/antibiotics-burtin.html"
 
 [[resources.licenses]]
+name  = "BSD-3-Clause"
 title = "BSD License (via Protovis)"
 path  = "https://mbostock.github.io/protovis/"
 
@@ -218,6 +225,7 @@ title = "StatLib Datasets Archive"
 path  = "http://lib.stat.cmu.edu/datasets/"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "The original was distributed in 1982 for educational and scientific purposes."
 path  = "http://lib.stat.cmu.edu/datasets/cars.desc"
 
@@ -243,6 +251,7 @@ title = "In-situ CO2 Data"
 path  = "https://scrippsco2.ucsd.edu/assets/data/atmospheric/stations/in_situ_co2/monthly/monthly_in_situ_co2_mlo.csv"
 
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons Attribution 4.0"
 path  = "https://creativecommons.org/licenses/by/4.0/"
 
@@ -299,6 +308,7 @@ path    = "https://docs.google.com/spreadsheets/d/1aLtIpAWvDGGa9k2XXEz6hZugWn0wC
 version = "14"
 
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons Attribution 4.0 International"
 path  = "https://www.gapminder.org/free-material/"
 
@@ -357,6 +367,7 @@ in the Hospitals of the Army in the East.
 path = "https://nrs.lib.harvard.edu/urn-3:hms.count:1177146?n=21"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "Harvard Library - Digitized Content Copyright & Viewer Terms of Use"
 path  = "https://library.harvard.edu/privacy-terms-use-copyright-information#digitizedcontent"
 
@@ -375,9 +386,11 @@ title = "Hannah Ritchie, Pablo Rosado and Max Roser (2022) - Natural Disasters"
 path  = "https://ourworldindata.org/natural-catastrophes"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "EM-DAT terms of use"
 path  = "https://doc.emdat.be/docs/legal/terms-of-use/"
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons BY license (Our World in Data)"
 path  = "https://creativecommons.org/licenses/by/4.0/"
 
@@ -423,6 +436,7 @@ title = "USGS Earthquake Feed"
 path  = "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Public Domain"
 path  = "https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits"
 
@@ -435,6 +449,7 @@ title = "Mozilla Firefox"
 path  = "https://www.mozilla.org/firefox/"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "Mozilla Trademark License"
 path  = "https://www.mozilla.org/en-US/foundation/trademarks/policy/"
 
@@ -587,6 +602,7 @@ a destination airport, and the count of flights along this route."""
 title = "U.S. Bureau of Transportation Statistics"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -605,7 +621,8 @@ title = "OpenFootball"
 path  = "https://github.com/openfootball/football.json"
 
 [[resources.licenses]]
-path = "https://github.com/openfootball/football.json?tab=readme-ov-file#license"
+name  = "other-pd"
+path  = "https://github.com/openfootball/football.json?tab=readme-ov-file#license"
 
 [[resources]] # Path: gapminder-health-income.csv
 path = "gapminder-health-income.csv"
@@ -625,6 +642,7 @@ path  = "https://www.gapminder.org"
 title = "Gapminder GDP Per Capita Data"
 path  = "https://docs.google.com/spreadsheets/d/1i5AEui3WZNZqh7MQ4AKkJuCz4rRxGR_pw_9gtbcBOqQ/edit?gid=501532268#gid=501532268"
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons Attribution 4.0 International"
 path  = "https://www.gapminder.org/free-material/"
 
@@ -725,6 +743,7 @@ title = "Gapminder Data Documentation"
 path  = "https://www.gapminder.org/data/documentation/"
 
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons Attribution 4.0 International"
 path  = "https://www.gapminder.org/free-material/"
 
@@ -737,7 +756,8 @@ title = "GIMP - About GIMP"
 path  = "https://www.gimp.org/about/"
 
 [[resources.licenses]]
-path = "https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it"
+name  = "notspecified"
+path  = "https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it"
 
 [[resources]] # Path: github.csv
 path = "github.csv"
@@ -758,7 +778,8 @@ description = "Simulated hourly commit counts"
 title = """Generated using `/scripts/github.py`."""
 
 [[resources.licenses]]
-path = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
+name  = "BSD-3-Clause"
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
 
 [[resources]] # Path: global-temp.csv
 path        = "global-temp.csv"
@@ -769,6 +790,7 @@ title = "NASA Goddard Institute for Space Studies"
 path  = "https://data.giss.nasa.gov/gistemp/"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -789,9 +811,9 @@ title = "Census Bureau Data API User Guide"
 path  = "https://www.census.gov/data/developers/guidance/api-user-guide.html"
 
 [[resources.licenses]]
+name  = "other-open"
 title = "U.S. Census Bureau API Terms of Service"
 path  = "https://www.census.gov/data/developers/about/terms-of-service.html"
-name  = "Census Bureau Terms of Use"
 
 [[resources]] # Path: iowa-electricity.csv
 path = "iowa-electricity.csv"
@@ -803,6 +825,7 @@ title = "U.S. Energy Information Administration"
 path  = "https://www.eia.gov/beta/electricity/data/browser/#/topic/0?agg=2,0,1&fuel=vvg&geo=00000g&sec=g&linechart=ELEC.GEN.OTH-IA-99.A~ELEC.GEN.COW-IA-99.A~ELEC.GEN.PEL-IA-99.A~ELEC.GEN.PC-IA-99.A~ELEC.GEN.NG-IA-99.A~~ELEC.GEN.NUC-IA-99.A~ELEC.GEN.HYC-IA-99.A~ELEC.GEN.AOR-IA-99.A~ELEC.GEN.HPS-IA-99.A~&columnchart=ELEC.GEN.ALL-IA-99.A&map=ELEC.GEN.ALL-IA-99.A&freq=A&start=2001&end=2017&ctype=linechart&ltype=pin&tab=overview&maptype=0&rse=0&pin="
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -870,6 +893,7 @@ path    = "https://usa.ipums.org/usa/"
 version = "6.0"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "IPUMS Terms of Use"
 path  = "https://www.ipums.org/about/terms"
 
@@ -894,6 +918,7 @@ title = "Statistical GIS Boundary Files, London Datastore"
 path  = "https://data.london.gov.uk/dataset/statistical-gis-boundary-files-london"
 
 [[resources.licenses]]
+name  = "OGL-UK-3.0"
 title = "UK Open Government License"
 path  = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
@@ -906,6 +931,7 @@ title = "[londonBoroughs.json](https://github.com/vega/vega-datasets/blob/main/d
 path  = "https://github.com/vega/vega-datasets/blob/main/data/londonBoroughs.json"
 
 [[resources.licenses]]
+name  = "OGL-UK-3.0"
 title = "UK Open Government License"
 path  = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
@@ -922,6 +948,7 @@ title = "OpenStreetMap Data (processed by oobrien/vis)"
 path  = "https://github.com/oobrien/vis/blob/master/tubecreature/data/tfl_lines.json"
 
 [[resources.licenses]]
+name  = "ODbL-1.0"
 title = "Open Data Commons Open Database License (ODbL)"
 path  = "https://opendatacommons.org/licenses/odbl/"
 
@@ -934,7 +961,8 @@ mapping people to groups. Used to [demonstrate](https://vega.github.io/vega-lite
 title = "Generated Data"
 
 [[resources.licenses]]
-path = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
+name  = "BSD-3-Clause"
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
 
 [[resources]] # Path: lookup_people.csv
 path = "lookup_people.csv"
@@ -946,7 +974,8 @@ to [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup`
 title = "Generated Data"
 
 [[resources.licenses]]
-path = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
+name  = "BSD-3-Clause"
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
 
 [[resources]] # Path: miserables.json
 path = "miserables.json"
@@ -961,7 +990,8 @@ title = "D. E. Knuth, The Stanford GraphBase: A Platform for Combinatorial Compu
 path  = "https://www-cs-faculty.stanford.edu/~knuth/sgb.html"
 
 [[resources.licenses]]
-path = "https://websites.umich.edu/~mejn/netdata/"
+name  = "notspecified"
+path  = "https://websites.umich.edu/~mejn/netdata/"
 
 [[resources]] # Path: monarchs.json
 path = "monarchs.json"
@@ -1015,6 +1045,7 @@ title = "The Royal Family - Interregnum"
 path  = "https://www.royal.uk/interregnum-1649-1660"
 
 [[resources.licenses]]
+name  = "OGL-UK-3.0"
 title = "Open Government Licence v3.0 (UK)"
 path  = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
@@ -1055,7 +1086,8 @@ description = "mean: -0.011, std: 0.199, range: [-0.534, 0.606], p-value: 0.763"
 title = "Generated Data"
 
 [[resources.licenses]]
-path = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
+name  = "BSD-3-Clause"
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
 
 [[resources]] # Path: obesity.json
 path = "obesity.json"
@@ -1067,6 +1099,7 @@ title = "Protovis"
 path  = "https://mbostock.github.io/protovis/ex/us_stats.js"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1176,6 +1209,7 @@ title = "OpenFEC API"
 path  = "https://api.open.fec.gov/developers/"
 
 [[resources.licenses]]
+name  = "CC0-1.0"
 title = "Creative Commons Zero 1.0 Universal"
 path  = "https://creativecommons.org/publicdomain/zero/1.0/"
 
@@ -1215,6 +1249,7 @@ title = "IPUMS USA"
 path  = "https://usa.ipums.org/usa/"
 
 [[resources.licenses]]
+name  = "notspecified"
 title = "IPUMS Terms of Use"
 path  = "https://www.ipums.org/about/terms"
 
@@ -1234,6 +1269,7 @@ title = "NOAA National Climatic Data Center"
 path  = "https://www.ncdc.noaa.gov/cdo-web/datatools/records"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1250,6 +1286,7 @@ title = "NOAA National Climatic Data Center (NCDC)"
 path  = "https://www.ncdc.noaa.gov/cdo-web/datatools/normals"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1290,6 +1327,7 @@ title = "NOAA National Climatic Data Center"
 path  = "https://www.ncdc.noaa.gov/cdo-web/datatools/records"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1369,6 +1407,7 @@ title = "US Census Bureau Cartographic Boundary Files (1:10,000,000)"
 path  = "https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1479,6 +1518,7 @@ title = "Bureau of Labor Statistics Table A-31"
 path  = "https://www.bls.gov/web/empsit/cpseea31.htm"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1530,6 +1570,7 @@ title = "BLS Handbook of Methods"
 path  = "https://www.bls.gov/opub/hom/lau/home.htm"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1554,7 +1595,8 @@ description = "mean: -0.013, std: 0.276, range: [-0.500, 0.498]"
 title = "Generated Data"
 
 [[resources.licenses]]
-path = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
+name  = "BSD-3-Clause"
+path  = "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
 
 [[resources]] # Path: us-10m.json
 path = "us-10m.json"
@@ -1573,6 +1615,7 @@ title = "US Census Bureau Cartographic Boundary FIles"
 path  = "https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html"
 
 [[resources.licenses]]
+name  = "ISC"
 title = "TopoJSON US Atlas ISC License"
 path  = "https://github.com/topojson/us-atlas/blob/master/LICENSE.md"
 
@@ -1600,6 +1643,7 @@ title = "U.S. Bureau of Labor Statistics Current Employment Statistics"
 path  = "https://www.bls.gov/ces/"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1623,10 +1667,12 @@ title = "U.S. Geological Survey National Geospatial Program - The National Map"
 path  = "https://www.usgs.gov/programs/national-geospatial-program/national-map"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Public Domain"
 path  = "https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1683,6 +1729,7 @@ title = "NOAA Climate Data Online"
 path  = "http://www.ncdc.noaa.gov/cdo-web/datatools/findstation"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "U.S. Government Dataset"
 path  = "https://www.usa.gov/government-works"
 
@@ -1710,6 +1757,7 @@ title = "1822 Playfair Chart"
 path  = "https://commons.wikimedia.org/wiki/File:Chart_Showing_at_One_View_the_Price_of_the_Quarter_of_Wheat,_and_Wages_of_Labour_by_the_Week,_from_1565_to_1821.png"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "Public Domain"
 path  = "https://commons.wikimedia.org/wiki/Public_domain"
 
@@ -1738,10 +1786,12 @@ title = "Natural Earth Data - Admin 0 Countries (1:110m)"
 path  = "https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/"
 
 [[resources.licenses]]
+name  = "ISC"
 title = "TopoJSON World Atlas ISC License"
 path  = "https://github.com/topojson/world-atlas/blob/master/LICENSE.md"
 
 [[resources.licenses]]
+name  = "other-pd"
 title = "Natural Earth Data Public Domain"
 path  = "https://www.naturalearthdata.com/about/terms-of-use/"
 
@@ -1763,5 +1813,6 @@ title = "GeoNames Postal Codes"
 path  = "https://download.geonames.org/export/zip/"
 
 [[resources.licenses]]
+name  = "CC-BY-4.0"
 title = "Creative Commons Attribution 4.0 International"
 path  = "https://creativecommons.org/licenses/by/4.0/"

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -470,8 +470,9 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "datetime"
+name   = "date"
+type   = "datetime"
+format = "%Y/%m/%d %H:%M"
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
@@ -523,8 +524,9 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "datetime"
+name   = "date"
+type   = "datetime"
+format = "%Y/%m/%d %H:%M"
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
@@ -544,8 +546,9 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "datetime"
+name   = "date"
+type   = "datetime"
+format = "%Y/%m/%d %H:%M"
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
@@ -558,10 +561,16 @@ title = "Data Collected Under U.S. DOT Regulatory Requirements - License Terms N
 
 [[resources]] # Path: flights-3m.parquet
 path = "flights-3m.parquet"
-description = """Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics. 
-Collected under regulatory reporting requirements (14 CFR Part 234), which mandate 
-that qualifying airlines report on-time performance data to BTS. Transformed using 
+description = """Flight delay statistics (3 million rows) from U.S. Bureau of Transportation Statistics.
+Collected under regulatory reporting requirements (14 CFR Part 234), which mandate
+that qualifying airlines report on-time performance data to BTS. Transformed using
 `/scripts/flights.py`"""
+
+[resources.schema]
+[[resources.schema.fields]]
+name   = "date"
+type   = "datetime"
+format = "%Y/%m/%d %H:%M"
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
@@ -581,8 +590,9 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "datetime"
+name   = "date"
+type   = "datetime"
+format = "%Y/%m/%d %H:%M"
 
 [[resources.sources]]
 title = "U.S. Bureau of Transportation Statistics"
@@ -1057,8 +1067,9 @@ resource for developing data cleaning and validation skills in real-world analys
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "Release Date"
-type = "date"
+name   = "Release Date"
+type   = "date"
+format = "%b %d %Y"
 
 [[resources]] # Path: normal-2d.json
 path = "normal-2d.json"
@@ -1198,8 +1209,9 @@ Additionally, the FEC's Github [repository](https://github.com/fecgov/FEC) state
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "Coverage_End_Date"
-type = "date"
+name   = "Coverage_End_Date"
+type   = "date"
+format = "%m/%d/%Y"
 
 [[resources.sources]]
 title = "Federal Election Commission Bulk Data"
@@ -1347,8 +1359,9 @@ the dot-com bubble burst (2000-2002), the mid-2000s bull market, and the 2008 fi
 """
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "date"
+name        = "date"
+type        = "date"
+format      = "%b %d %Y"
 description = "Date of monthly observation in the format 'MMM D YYYY'"
 
 [[resources.schema.fields]]
@@ -1417,8 +1430,9 @@ description = "Monthly stock prices for five companies from 2000 to 2010."
 
 [resources.schema]
 [[resources.schema.fields]]
-name = "date"
-type = "date"
+name   = "date"
+type   = "date"
+format = "%b %d %Y"
 
 [[resources]] # Path: udistrict.json
 path = "udistrict.json"

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -469,11 +469,13 @@ IDs correspond to those in `flare.json`."""
 name        = "source"
 type        = "integer"
 description = "ID of the class that has the dependency (the importer)"
+constraints = { required = true }
 
 [[resources.schema.fields]]
 name        = "target"
 type        = "integer"
 description = "ID of the class being depended upon (the imported)"
+constraints = { required = true }
 
 [[resources]] # Path: flare.json
 path        = "flare.json"
@@ -491,21 +493,25 @@ Represents a tree structure where nodes have different fields depending on their
 name        = "id"
 type        = "integer"
 description = "Unique identifier for the node"
+constraints = { required = true }
 
 [[resources.schema.fields]]
 name        = "name"
 type        = "string"
 description = "Name of the node in the hierarchy"
+constraints = { required = true }
 
 [[resources.schema.fields]]
 name        = "parent"
 type        = "integer"
 description = "ID of parent node (absent for root node)"
+constraints = { required = false }
 
 [[resources.schema.fields]]
 name        = "size"
 type        = "integer"
 description = "Size value (only present on leaf nodes)"
+constraints = { required = false }
 
 [[resources]] # Path: flights-10k.json
 path = "flights-10k.json"

--- a/_data/datapackage_additions.toml
+++ b/_data/datapackage_additions.toml
@@ -1232,7 +1232,8 @@ title = "Allison Horst's Penguins Repository"
 path  = "https://github.com/allisonhorst/penguins"
 
 [[resources.licenses]]
-name = "CC0 1.0 Universal"
+name  = "CC0-1.0"
+title = "Creative Commons Zero 1.0 Universal"
 path = "https://github.com/allisonhorst/palmerpenguins?tab=CC0-1.0-1-ov-file#readme"
 
 [[resources]] # Path: platformer-terrain.json

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "3.2.1",
-  "created": "2026-02-01T19:49:53.064433+00:00",
+  "created": "2026-02-02T02:05:43.544254+00:00",
   "resources": [
     {
       "name": "icon_7zip",
@@ -1164,12 +1164,18 @@
           {
             "name": "source",
             "type": "integer",
-            "description": "ID of the class that has the dependency (the importer)"
+            "description": "ID of the class that has the dependency (the importer)",
+            "constraints": {
+              "required": true
+            }
           },
           {
             "name": "target",
             "type": "integer",
-            "description": "ID of the class being depended upon (the imported)"
+            "description": "ID of the class being depended upon (the imported)",
+            "constraints": {
+              "required": true
+            }
           }
         ]
       }
@@ -1195,12 +1201,18 @@
           {
             "name": "id",
             "type": "integer",
-            "description": "Unique identifier for the node"
+            "description": "Unique identifier for the node",
+            "constraints": {
+              "required": true
+            }
           },
           {
             "name": "name",
             "type": "string",
-            "description": "Name of the node in the hierarchy"
+            "description": "Name of the node in the hierarchy",
+            "constraints": {
+              "required": true
+            }
           }
         ]
       }

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "3.2.1",
-  "created": "2026-02-02T02:05:43.544254+00:00",
+  "created": "2026-02-02T13:19:39.437222+00:00",
   "resources": [
     {
       "name": "icon_7zip",
@@ -2668,7 +2668,8 @@
       "description": "Records of morphological measurements and demographic information from 344 Palmer Archipelago \npenguins across three species. Collected by [Dr. Kristen Gorman](https://www.uaf.edu/cfos/people/faculty/detail/kristen-gorman.php) and the Palmer Station Antarctica [LTER](https://lternet.edu/). \nData gathering occurred as part of Palmer Station's long-term ecological research, contributing to studies of Antarctic marine\necosystems and penguin biology. All measurements follow standardized units, enabling research into morphological \nvariations between species and sexual dimorphism in Antarctic penguins. \n",
       "licenses": [
         {
-          "name": "CC0 1.0 Universal",
+          "name": "CC0-1.0",
+          "title": "Creative Commons Zero 1.0 Universal",
           "path": "https://github.com/allisonhorst/palmerpenguins?tab=CC0-1.0-1-ov-file#readme"
         }
       ],

--- a/datapackage.json
+++ b/datapackage.json
@@ -20,7 +20,7 @@
     }
   ],
   "version": "3.2.1",
-  "created": "2025-08-21T23:04:37.691343+00:00",
+  "created": "2026-02-01T19:49:53.064433+00:00",
   "resources": [
     {
       "name": "icon_7zip",
@@ -28,6 +28,7 @@
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
         {
+          "name": "LGPL-2.1",
           "title": "GNU Lesser General Public License",
           "path": "https://www.7-zip.org/license.txt"
         }
@@ -108,6 +109,7 @@
       "description": "A raster grid of global annual precipitation for the year 2016 at a resolution 1 degree of lon/lat per cell.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "Public Domain",
           "path": "https://www.weather.gov/disclaimer/"
         }
@@ -175,7 +177,8 @@
       "description": "Yields of barley varieties from experiments conducted by the Minnesota Agricultural\nExperiment Station (MAES) across six sites in Minnesota. The USDA Technical Bulletin No. 735\n(December 1940) republished these yields data with explicit credit to MAES as the source.\n\nIt was analyzed by agronomists F.R. Immer, H.K. Hayes, and L. Powers in the 1934 paper \"Statistical Determination of Barley Varietal Adaption\".\n\nR.A. Fisher popularized its use in the field of statistics when he included it in his book \"The Design of Experiments\".\n\nSince then it has been used to demonstrate new visualization techniques, including the trellis charts developed by Richard Becker, William Cleveland and others in the 1990s.\n",
       "licenses": [
         {
-          "name": "Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified"
+          "name": "notspecified",
+          "title": "Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified"
         }
       ],
       "sources": [
@@ -227,6 +230,7 @@
       "description": "Records of reported wildlife strikes received by the U.S. FAA",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://resources.data.gov/open-licenses/"
         }
@@ -311,6 +315,7 @@
       "description": "Historical and forecasted federal revenue/receipts produced in 2016 by the U.S. Office of Management and Budget.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://resources.data.gov/open-licenses/"
         }
@@ -632,6 +637,7 @@
       "description": "U.S. federal budget projections and actual outcomes from 1980 through 2010. Originally [analyzed](https://archive.nytimes.com/www.nytimes.com/interactive/2010/02/02/us/politics/20100201-budget-porcupine-graphic.html) by The New York Times in 2010. \nReveals how budget forecasts made in any given year compared to what actually happened, \nwith positive values indicating surpluses (briefly seen around 2000) and negative values \nrepresenting deficits (reaching a particularly large value of -$1.78 trillion during the 2008-2009 financial crisis).",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://resources.data.gov/open-licenses/"
         }
@@ -680,6 +686,7 @@
       "description": "Compares the performance of three antibiotics against 16 different bacteria. Based on graphic designer \nWill Burtin's 1951 visualization of antibiotic effectiveness, originally published in Scope Magazine and\nfeatured as an example in the Protovis project, a precursor to D3.js.\n\nNumerical values represent the minimum inhibitory concentration (MIC) of each antibiotic, \nmeasured in units per milliliter, with lower values indicating higher antibiotic\neffectiveness.\n\nAs noted in the Protovis example, \"Recreating this display revealed some minor errors in the original: a missing grid line at 0.01 μg/ml, and an exaggeration of some values for penicillin\".\n\nThe vega-datsets version is largely consistent with the Protovis version, with one correction (changing 'Brucella antracis' to the correct 'Bacillus anthracis') and the addition of a new column, 'Genus', to group related bacterial species together.\n\nThe caption of the original 1951 [visualization](https://graphicdesignarchives.org/wp-content/uploads/wmgda_8616c.jpg) \nreads as follows:\n\n> #### Antibacterial ranges of Neomycin, Penicillin and Streptomycin\n>\n>\n> The chart compares the in vitro sensitivities to neomycin of some of the common pathogens (gram+ in red and gram- in blue) with their sensitivities to penicillin, and streptomycin.\n>\n> The effectiveness of the antibiotics is expressed as the highest dilution in μ/ml. which inhibits the test organism.\n>\n> High dilutions are toward the periphery; consequently the length of the colored bar is proportional to the effectiveness.\n>\n> It is apparent that neomycin is especially effective against Staph. albus and aureus, Streph. fecalis, A. aerogenes, S. typhosa, E. coli, Ps. aeruginosa, Br. abortus, K. pneumoniae, Pr. vulgaris, S. schottmuelleri and M. tuberculosis.\n>\n> Unfortunately, some strains of proteus, pseudomonas and hemolytic streptococcus are resistant to neomycin, although the majority of these are sensitive to neomycin.\n>\n> It also inhibits actinomycetes, but is inactive against viruses and fungi. Its mode of action is not understood.\n",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "title": "BSD License (via Protovis)",
           "path": "https://mbostock.github.io/protovis/"
         }
@@ -741,6 +748,7 @@
       "description": "Collection of car specifications and performance metrics from various automobile manufacturers.",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "The original was distributed in 1982 for educational and scientific purposes.",
           "path": "http://lib.stat.cmu.edu/datasets/cars.desc"
         }
@@ -771,7 +779,7 @@
           },
           {
             "name": "Miles_per_Gallon",
-            "type": "integer"
+            "type": "number"
           },
           {
             "name": "Cylinders",
@@ -810,6 +818,7 @@
       "description": "Atmospheric CO2 concentration measurements from Mauna Loa Observatory, Hawaii. \nContains monthly readings from 1958-2020 with two key measurements:\n1. CO2 concentrations in millionths of a [mole](https://en.wikipedia.org/wiki/Mole_(unit)) of CO2 \nper mole of air (parts per million), reported on the 2012 \nSIO manometric mole fraction scale\n2. Seasonally adjusted values where a [4-harmonic fit](https://en.wikipedia.org/wiki/Harmonic_analysis) with linear gain factor \nhas been subtracted to remove the quasi-regular seasonal cycle\nValues are adjusted to 24:00 hours on the 15th of each month. \nOnly includes rows with valid data.\n",
       "licenses": [
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons Attribution 4.0",
           "path": "https://creativecommons.org/licenses/by/4.0/"
         }
@@ -854,6 +863,7 @@
       "description": "Key demographic indicators (life expectancy at birth and fertility rate measured \nas babies per woman) for various countries from 1955 to 2000 at 5-year intervals. Includes both \ncurrent values and adjacent time period values (previous and next) for each indicator. Gapminder's \n[data documentation](https://www.gapminder.org/data/documentation/) notes that its philosophy is to fill data gaps with \nestimates and use current geographic boundaries for historical data. Gapminder states that it \naims to \"show people the big picture\" rather than support detailed numeric analysis.",
       "licenses": [
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons Attribution 4.0 International",
           "path": "https://www.gapminder.org/free-material/"
         }
@@ -927,6 +937,7 @@
       "description": "Monthly mortality rates from British military hospitals during the Crimean War (1854-1856), which informed \nFlorence Nightingale's groundbreaking work in public health. Nightingale credits Dr. William Farr for \ncompiling the data from the 1858 [Medical and Surgical History of the British Army](http://resource.nlm.nih.gov/62510370R). Categorizes \ndeaths into \"zymotic\" diseases (preventable infectious diseases), wounds/injuries, and other causes. \nCovering the period from April 1854 to March 1856, it includes monthly army strength \nalongside mortality figures. Transformed by Nightingale into her now-famous [polar area \ndiagrams](https://iiif.lib.harvard.edu/manifests/view/drs:7420433$25i). \n\nThe annual mortality rates plotted in the chart can be calculated using the formula \n> (Deaths &times; 1000 &times; 12) &divide; Army Size. \n\nAs [The Lancet](https://pmc.ncbi.nlm.nih.gov/articles/PMC7252134/) argued in 2020, Nightingale's \ninnovative visualizations proved that \"far more men died of disease, infection, and exposure \nthan in battle—a fact that shocked the British nation.\" Her work also vividly illustrated \nthe dramatic impact of sanitary reforms, particularly in reducing preventable deaths.",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "Harvard Library - Digitized Content Copyright & Viewer Terms of Use",
           "path": "https://library.harvard.edu/privacy-terms-use-copyright-information#digitizedcontent"
         }
@@ -985,10 +996,12 @@
       "description": "Annual number of deaths from disasters, sourced from EM-DAT (Emergency Events Database) \nmaintained by the Centre for Research on the Epidemiology of Disasters (CRED) at UCLouvain, Belgium. \nProcessed by Our World in Data to standardize country names and world region definitions, converting units,\ncalculating derived indicators, and adapting metadata. Deaths are reported as absolute numbers.",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "EM-DAT terms of use",
           "path": "https://doc.emdat.be/docs/legal/terms-of-use/"
         },
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons BY license (Our World in Data)",
           "path": "https://creativecommons.org/licenses/by/4.0/"
         }
@@ -1086,6 +1099,7 @@
       "description": "Represents approximately one week of continuous monitoring from USGS's \"all earthquakes\" \nreal-time feed, which includes 1,703 seismic events of all magnitudes recorded by the \nUSGS Earthquake Hazards Program from January 31 to February 7, 2018 (UTC). ",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Public Domain",
           "path": "https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits"
         }
@@ -1110,6 +1124,7 @@
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "Mozilla Trademark License",
           "path": "https://www.mozilla.org/en-US/foundation/trademarks/policy/"
         }
@@ -1131,7 +1146,7 @@
     {
       "name": "flare_dependencies",
       "type": "table",
-      "description": "Indicates, with `flare.json`, relationships among classes in a software hierarchy.",
+      "description": "Network of class dependencies for the Flare visualization library. Each entry\nrepresents a directed edge where the `source` class depends on (imports) the `target` class.\nIDs correspond to those in `flare.json`.",
       "path": "flare-dependencies.json",
       "scheme": "file",
       "format": "json",
@@ -1148,11 +1163,13 @@
         "fields": [
           {
             "name": "source",
-            "type": "integer"
+            "type": "integer",
+            "description": "ID of the class that has the dependency (the importer)"
           },
           {
             "name": "target",
-            "type": "integer"
+            "type": "integer",
+            "description": "ID of the class being depended upon (the imported)"
           }
         ]
       }
@@ -1160,7 +1177,7 @@
     {
       "name": "flare",
       "type": "table",
-      "description": "Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy.",
+      "description": "Class hierarchy of the Flare visualization library. Used with `flare-dependencies.json`\nto represent the complete package/class structure.\n\nRepresents a tree structure where nodes have different fields depending on their role:\n- Root node: only `id` and `name`\n- Branch nodes: `id`, `name`, and `parent`\n- Leaf nodes: `id`, `name`, `parent`, and `size`\n",
       "path": "flare.json",
       "scheme": "file",
       "format": "json",
@@ -1177,11 +1194,13 @@
         "fields": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "integer",
+            "description": "Unique identifier for the node"
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "description": "Name of the node in the hierarchy"
           }
         ]
       }
@@ -1219,7 +1238,8 @@
         "fields": [
           {
             "name": "date",
-            "type": "datetime"
+            "type": "datetime",
+            "format": "%Y/%m/%d %H:%M"
           },
           {
             "name": "delay",
@@ -1359,7 +1379,8 @@
         "fields": [
           {
             "name": "date",
-            "type": "datetime"
+            "type": "datetime",
+            "format": "%Y/%m/%d %H:%M"
           },
           {
             "name": "delay",
@@ -1413,7 +1434,8 @@
         "fields": [
           {
             "name": "date",
-            "type": "datetime"
+            "type": "datetime",
+            "format": "%Y/%m/%d %H:%M"
           },
           {
             "name": "delay",
@@ -1461,7 +1483,8 @@
         "fields": [
           {
             "name": "date",
-            "type": "datetime"
+            "type": "datetime",
+            "format": "%Y/%m/%d %H:%M"
           },
           {
             "name": "delay",
@@ -1515,7 +1538,8 @@
         "fields": [
           {
             "name": "date",
-            "type": "datetime"
+            "type": "datetime",
+            "format": "%Y/%m/%d %H:%M"
           },
           {
             "name": "delay",
@@ -1539,17 +1563,15 @@
     {
       "name": "flights_airport",
       "type": "table",
-      "description": "Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id), \na destination airport, and the count of flights along this route.",
+      "description": "Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id),\na destination airport, and the count of flights along this route.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
       ],
       "sources": [
-        {
-          "title": "U.S. Bureau of Transportation Statistics"
-        },
         {
           "title": "U.S. Bureau of Transportation Statistics",
           "path": "https://www.transtats.bts.gov/DL_SelectFields.asp?gnoyr_VQ=FGJ&QO_fu146_anzr=b0-gvzr"
@@ -1585,6 +1607,7 @@
       "description": "Football match outcomes across multiple divisions from 2013 to 2017, part of a\nlarger dataset from OpenFootball. The subset was made such that there are records for all five\nchosen divisions over the time period.",
       "licenses": [
         {
+          "name": "other-pd",
           "path": "https://github.com/openfootball/football.json?tab=readme-ov-file#license"
         }
       ],
@@ -1641,6 +1664,7 @@
       "description": "Per-capita income, life expectancy, population and regional grouping. Reference year for the data is not specified. \nGapminder historical data is subject to revisions.\n\nGapminder (v30, 2023) defines per-capita income as follows:\n>\"This is real GDP per capita (gross domestic product per person adjusted for inflation) \n>converted to international dollars using purchasing power parity rates. An international dollar \n>has the same purchasing power over GDP as the U.S. dollar has in the United States.\"\n",
       "licenses": [
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons Attribution 4.0 International",
           "path": "https://www.gapminder.org/free-material/"
         }
@@ -1693,6 +1717,7 @@
       "description": "Combines key demographic indicators (life expectancy at birth, \npopulation, and fertility rate measured as babies per woman) for various countries from 1955 \nto 2005 at 5-year intervals. Includes a 'cluster' column, a categorical variable \ngrouping countries. Gapminder's data documentation notes that its philosophy is to fill data \ngaps with estimates and use current geographic boundaries for historical data. Gapminder \nstates that it aims to \"show people the big picture\" rather than support detailed numeric \nanalysis.\n\nNotes:\n1. Country Selection: The set of countries matches the version of this dataset \n   originally added to this collection in 2015. The specific criteria for country selection \n   in that version are not known. Data for Aruba are no longer available in the new version. \n   Hong Kong has been revised to Hong Kong, China in the new version.\n\n2. Data Precision: The precision of float values may have changed from the original version. \n   These changes reflect the most recent source data used for each indicator.\n\n3. Regional Groupings: To preserve continuity with previous versions of this dataset, we have retained the column \n   name 'cluster' instead of renaming it to 'six_regions'. \n",
       "licenses": [
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons Attribution 4.0 International",
           "path": "https://www.gapminder.org/free-material/"
         }
@@ -1818,6 +1843,7 @@
       "description": "Application icon from open-source software project. Used in [Image-based Scatter Plot example](https://vega.github.io/vega-lite/examples/scatter_image.html).",
       "licenses": [
         {
+          "name": "notspecified",
           "path": "https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it"
         }
       ],
@@ -1841,12 +1867,14 @@
       "description": "Simulated GitHub contribution data showing hourly commit counts across \ndifferent times of day. Designed to demonstrate typical patterns of developer activity \nin a GitHub-style punchcard visualization format.",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "path": "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
         }
       ],
       "sources": [
         {
-          "title": "Generated using `/scripts/github.py`."
+          "title": "Generated using `/scripts/github.py`.",
+          "path": "https://github.com/vega/vega-datasets/blob/main/scripts/github.py"
         }
       ],
       "path": "github.csv",
@@ -1877,6 +1905,7 @@
       "description": "Combined Land-Surface Air and Sea-Surface Water Temperature Anomalies (Land-Ocean Temperature Index, L-OTI), 1880-2023.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -1913,9 +1942,9 @@
       "description": "Household income distribution by US state, derived from the \nCensus Bureau's American Community Survey 3-Year Data (2013). The dataset \nshows the percentage of households within different income brackets for each state.\nGenerated using `/scripts/income.py`. This product uses the Census Bureau Data API \nbut is not endorsed or certified by the Census Bureau.",
       "licenses": [
         {
+          "name": "other-open",
           "title": "U.S. Census Bureau API Terms of Service",
-          "path": "https://www.census.gov/data/developers/about/terms-of-service.html",
-          "name": "Census Bureau Terms of Use"
+          "path": "https://www.census.gov/data/developers/about/terms-of-service.html"
         }
       ],
       "sources": [
@@ -1975,6 +2004,7 @@
       "description": "Annual net generation of electricity in Iowa by source, in thousand megawatthours. U.S. EIA data downloaded on May 6, 2018. \nUseful for illustrating stacked area charts. Demonstrates dramatic increase in wind power production.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -2015,6 +2045,7 @@
       "description": "U.S. census data on [occupations](https://usa.ipums.org/usa-action/variables/OCC1950#codes_section) by sex and year across decades between 1850 and 2000. Obtained from IPUMS USA, which \"collects, preserves and harmonizes U.S. census microdata\" from as early as 1790.\n\nOriginally created for a 2006 data visualization project called *sense.us* by IBM Research (Jeff Heer, Martin Wattenberg and Fernanda Viégas), described [here](https://homes.cs.washington.edu/~jheer/files/bdata_ch12.pdf). \nThe dataset is also referenced in this vega [example](https://vega.github.io/vega/examples/job-voyager/).\n\nBased on a tabulation of the [OCC1950](https://usa.ipums.org/usa-action/variables/OCC1950) variable by sex across IPUMS USA samples. Appears to be derived from Version 6.0 (2015) of IPUMS USA, according to 2024 correspondence with the IPUMS Project. IPUMS has made improvements to occupation coding since version 6, particularly for 19th-century samples, which may result in discrepancies between this dataset and current IPUMS data. Details on data revisions are available [here](https://usa.ipums.org/usa-action/revisions).\n\nIPUMS USA confirmed in 2024 correspondence that hosting this dataset on vega-datasets is permissible, stating:\n>We're excited to hear that this dataset made its way to this repository and is being used by students for data visualization. We allow for these types of redistributions of summary data so long as the underlying microdata records are not shared.\n\n1. Represents summary data. Underlying microdata records are not included.\n2. Users attempting to replicate or extend this data should use the [PERWT](https://usa.ipums.org/usa-action/variables/PERWT#description_section) \n(person weight) variable as an expansion factor when working with IPUMS USA extracts.\n3. Due to coding revisions, figures for earlier years (particularly 19th century) may not match current IPUMS USA data exactly.\n\nWhen using this dataset, please refer to IPUMS USA [terms of use](https://usa.ipums.org/usa/terms.shtml).\nThe organization requests use of the following citation for this json file:\n\nSteven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. Integrated Public Use Microdata Series: Version 6.0. Minneapolis: University of Minnesota, 2015. http://doi.org/10.18128/D010.V6.0\n",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "IPUMS Terms of Use",
           "path": "https://www.ipums.org/about/terms"
         }
@@ -2140,6 +2171,7 @@
       "description": "Boundaries of London boroughs reprojected and simplified from `London_Borough_Excluding_MHW` shapefile. \nOriginal data \"contains National Statistics data © Crown copyright and database right (2015)\" \nand \"Contains Ordnance Survey data © Crown copyright and database right [2015].",
       "licenses": [
         {
+          "name": "OGL-UK-3.0",
           "title": "UK Open Government License",
           "path": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
@@ -2164,6 +2196,7 @@
       "description": "Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/d3-geo/math#geoCentroid).",
       "licenses": [
         {
+          "name": "OGL-UK-3.0",
           "title": "UK Open Government License",
           "path": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
@@ -2209,6 +2242,7 @@
       "description": "A [topologically-encoded](https://github.com/topojson/topojson) representation of select London Underground rail lines, derived from OpenStreetMap\ndata. These 394 LineString geometries, encoded using 406 arcs, depict transport paths between stations with stations marked as nodes\nalong the lines. Originally transformed from a GeoJSON intermediary `tfl_lines.json` into TopoJSON format, this network configuration \nreflects the system as of February 4, 2018, and may not incorporate subsequent modifications or expansions.\n",
       "licenses": [
         {
+          "name": "ODbL-1.0",
           "title": "Open Data Commons Open Database License (ODbL)",
           "path": "https://opendatacommons.org/licenses/odbl/"
         }
@@ -2233,6 +2267,7 @@
       "description": "A nine-row lookup table for the `lookup_people.csv` dataset, \nmapping people to groups. Used to [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup` transforms.",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "path": "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
         }
       ],
@@ -2267,6 +2302,7 @@
       "description": "A synthetic list of nine people and their associated name, age, \nand height in centimeters. Used in conjunction with `lookup_groups.csv` \nto [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup` transforms.",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "path": "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
         }
       ],
@@ -2305,6 +2341,7 @@
       "description": "A weighted network of coappearances of characters in Victor Hugo's novel \"Les Miserables\". \nNodes represent characters as indicated by the labels and edges connect any pair of characters \nthat appear in the same chapter of the book. The values on the edges are the number of such \ncoappearances.\n",
       "licenses": [
         {
+          "name": "notspecified",
           "path": "https://websites.umich.edu/~mejn/netdata/"
         }
       ],
@@ -2328,6 +2365,7 @@
       "description": "A chronological list of English and British monarchs from Elizabeth I through George IV.\n\nContains two intentional inaccuracies to maintain compatibility with \nthe [Wheat and Wages](https://vega.github.io/vega/examples/wheat-and-wages/) example visualization:\n1. the start date for the reign of Elizabeth I is shown as 1565, instead of 1558;\n2. the end date for the reign of George IV is shown as 1820, instead of 1830.\nThese discrepancies align the `monarchs.json` dataset with the start and end dates of the `wheat.json` dataset used in the visualization.\nThe entry \"W&M\" represents the joint reign of William III and Mary II. While the dataset shows their reign as 1689-1702, \nthe official Web site of the British royal family indicates that Mary II's reign ended in 1694, though William III continued to rule until 1702.\nThe `commonwealth` field is used to flag the period from 1649 to 1660, which includes the Commonwealth of England, the Protectorate, \nand the period leading to the Restoration. While historically more accurate to call this the \"interregnum,\" the field name of `commonwealth` \nfrom the original dataset is retained for backwards compatibility.\n\n> [!IMPORTANT]\n> Revised in Aug. 2024 to show James II's reign now ends in 1688 (previously 1689).\n\nSource data has been verified against the kings & queens and interregnum pages of the official website of the British royal family (retrieved in Aug. 2024).\n",
       "licenses": [
         {
+          "name": "OGL-UK-3.0",
           "title": "Open Government Licence v3.0 (UK)",
           "path": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
@@ -2382,7 +2420,7 @@
     {
       "name": "movies",
       "type": "table",
-      "description": "A collection of films and their performance metrics, including box office earnings, budgets, \nand audience ratings. Contains known data quality issues and intentional errors, serving as a teaching \nresource for developing data cleaning and validation skills in real-world analysis workflows.",
+      "description": "A collection of films and their performance metrics, including box office earnings, budgets,\nand audience ratings. Contains known data quality issues typical of real-world datasets:\n- Some movie titles with numeric names (1776, 2012, 300, etc.) are stored as JSON numbers rather than strings\n- Release dates use 'MMM DD YYYY' format rather than ISO 8601\n\nThese characteristics make it suitable as a teaching resource for developing data cleaning\nand validation skills in real-world analysis workflows.",
       "path": "movies.json",
       "scheme": "file",
       "format": "json",
@@ -2419,7 +2457,8 @@
           },
           {
             "name": "Release Date",
-            "type": "date"
+            "type": "date",
+            "format": "%b %d %Y"
           },
           {
             "name": "MPAA Rating",
@@ -2470,6 +2509,7 @@
       "description": "Five hundred paired coordinates sampled from a bivariate normal distribution. The data is centered near the \norigin with standard deviations indicating a relatively equal spread in both dimensions. \nThe variables exhibit negligible correlation (0.026), suggesting independence. \n[Normality tests](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.normaltest.html) for each variable yield high p-values, supporting the normal distribution assumption. \nThese characteristics make it well-suited for demonstrating statistical visualization techniques \nin Vega and Vega-Lite, including scatter plots, density plots, heatmaps, and marginal histograms/density curves. \nIt can also serve as a clean baseline for testing new visualization methods or for educational purposes \nin data visualization and statistics.\nA contrast to uniformly distributed data in `uniform-2d.json`\n",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "path": "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
         }
       ],
@@ -2511,6 +2551,7 @@
       "description": "State-level obesity rates (BMI >= 30) for the U.S. in 1995. \nOriginally [Behavioral Risk Factor Surveillance System (BRFSS)](https://www.cdc.gov/brfss/index.html) statistics.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -2746,6 +2787,7 @@
       "description": "Summary financial information on contributions to candidates for U.S. \nelections. An updated version is available from the \"all candidates\" files (in pipe-delimited format)\non the bulk data download page of the U.S. Federal Election Commission, or, alternatively, via OpenFEC. \nInformation on each of the 25 columns is available from the [FEC All Candidates File Description](https://www.fec.gov/campaign-finance-data/all-candidates-file-description/).\nThe sample dataset in `political-contributions.json` contains 58 records with dates from 2015.\n\nFEC data is subject to the commission's:\n- [Sale or Use Policy](https://www.fec.gov/updates/sale-or-use-contributor-information/)\n- [Privacy and Security Policy](https://www.fec.gov/about/privacy-and-security-policy/)\n- [Acceptable Use Policy](https://github.com/fecgov/FEC/blob/master/ACCEPTABLE-USE-POLICY.md)\n\nAdditionally, the FEC's Github [repository](https://github.com/fecgov/FEC) states:\n> This project is in the public domain within the United States, and we waive worldwide \n> copyright and related rights through [CC0 universal public domain](https://creativecommons.org/publicdomain/zero/1.0/)\n> dedication. Read more on our [license](https://github.com/fecgov/FEC?tab=License-1-ov-file) page.\n> A few restrictions limit the way you can use FEC data. For example, you can't use \n> contributor lists for commercial purposes or to solicit donations. Learn more on \n> [FEC.gov](https://www.fec.gov/).",
       "licenses": [
         {
+          "name": "CC0-1.0",
           "title": "Creative Commons Zero 1.0 Universal",
           "path": "https://creativecommons.org/publicdomain/zero/1.0/"
         }
@@ -2864,7 +2906,8 @@
           },
           {
             "name": "Coverage_End_Date",
-            "type": "date"
+            "type": "date",
+            "format": "%m/%d/%Y"
           },
           {
             "name": "Refunds_to_Individuals",
@@ -2883,6 +2926,7 @@
       "description": "U.S. population counts by age group (0-90+ in 5-year intervals) and sex \nfor each decade between 1850 and 2000, collected and harmonized from historical census records by IPUMS USA.\n\nIPUMS updates and revises datasets over time, which may result in discrepancies with current IPUMS data.\n\nWhen using this dataset, please refer to IPUMS USA terms of use. The organization requests the \nuse of the following citation for this json file:\nSteven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. Integrated \nPublic Use Microdata Series: Version 6.0. Minneapolis: University of Minnesota, 2015. \nhttp://doi.org/10.18128/D010.V6.0\n",
       "licenses": [
         {
+          "name": "notspecified",
           "title": "IPUMS Terms of Use",
           "path": "https://www.ipums.org/about/terms"
         }
@@ -2936,6 +2980,7 @@
       "description": "Per-state population, number of engineers, and hurricanes. Used in Vega-Lite example,\n[Three Choropleths Representing Disjoint Data from the Same Table](https://vega.github.io/vega-lite/examples/geo_repeat.html)",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -2992,6 +3037,7 @@
       "description": "Hourly weather normals with metric units. The 1981-2010 Climate Normals are \nNCDC's three-decade averages of climatological variables, including temperature and \nprecipitation. Learn more in the [documentation](https://www1.ncdc.noaa.gov/pub/data/cdo/documentation/NORMAL_HLY_documentation.pdf).\nWe only included temperature, wind, and pressure \nand updated the format to be easier to parse.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3036,6 +3082,7 @@
       "description": "Daily weather in metric units. Transformed using `/scripts/weather.py`. \nThe categorical \"weather\" field is synthesized from multiple fields in the original dataset. \nThis data is intended for instructional purposes.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3161,7 +3208,8 @@
           {
             "name": "date",
             "type": "date",
-            "description": "Date of monthly observation in the format 'MMM D YYYY'"
+            "description": "Date of monthly observation in the format 'MMM D YYYY'",
+            "format": "%b %d %Y"
           },
           {
             "name": "price",
@@ -3177,6 +3225,7 @@
       "description": "Percentage of year-round habitat for four species -- American robin, white-tailed deer, \nAmerican bullfrog, and common gartersnake -- within US counties, derived from USGS \nGap Analysis Project (GAP) Species Habitat Maps. Data is provided at a 30-meter \nresolution and covers the contiguous United States. Habitat percentages are calculated \nby overlaying species habitat rasters (year-round habitat represented by value 3) with \nUS county boundaries.\n\nThe habitat maps are in Albers Conical Equal Area projection (EPSG:5070). County boundaries \nare derived from US Census Bureau cartographic boundary files (1:10,000,000 scale), from \n`US-10m.json` in this repository. This dataset only includes *year-round* habitat. \nThe original raster data also contains values for summer and winter habitat, which are \n*not* included in this dataset. Data was processed using the `exactextract` library \nfor zonal statistics.\n",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3252,7 +3301,8 @@
           },
           {
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "format": "%b %d %Y"
           },
           {
             "name": "price",
@@ -3296,6 +3346,7 @@
       "description": "Industry-level unemployment from the Current Population Survey \n(CPS), published monthly by the U.S. Bureau of Labor Statistics. Includes unemployed persons \nand unemployment rate across 11 private industries, as well as agricultural, government, and \nself-employed workers. Covers January 2000 through February 2010. Industry classification \nfollows format of CPS Table A-31. Transformed using `scripts/make-unemployment-across-industries.py`\n\nThe BLS Web site states:\n> \"Users of the public API should cite the date that data were accessed or retrieved using \n> the API. Users must clearly state that \"BLS.gov cannot vouch for the data or analyses \n> derived from these data after the data have been retrieved from BLS.gov.\" The BLS.gov logo \n> may not be used by persons who are not BLS employees or on products (including web pages) \n> that are not BLS-sponsored.\"\n\nSee full BLS [terms of service](https://www.bls.gov/developers/termsOfService.htm).",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3367,6 +3418,7 @@
       "description": "County-level unemployment rates in the United States, with data generally\nconsistent with levels reported in 2009. The dataset is structured as tab-separated values.\nThe unemployment rate represents the number of unemployed persons as a percentage of the labor\nforce. According to the Bureau of Labor Statistics (BLS) glossary:\n\nUnemployed persons (Current Population Survey) [are] persons aged 16 years and older who had\nno employment during the reference week, were available for work, except for temporary\nillness, and had made specific efforts to find employment sometime during the 4-week period\nending with the reference week. Persons who were waiting to be recalled to a job from which\nthey had been laid off need not have been looking for work to be classified as unemployed.\n\nDerived from the [Local Area Unemployment Statistics (LAUS)](https://www.bls.gov/lau/) program, \na federal-state cooperative effort overseen by the Bureau of Labor Statistics (BLS). \nThe LAUS program produces monthly and annual employment, unemployment, and labor force data for census regions and divisions,\nstates, counties, metropolitan areas, and many cities and towns.\n\nFor the most up-to-date LAUS data:\n1. **Monthly and Annual Data Downloads**:\n- Visit the [LAUS Data Tools](https://www.bls.gov/lau/data.htm) page for [monthly](https://www.bls.gov/lau/tables.htm#mcounty) \nand [annual](https://www.bls.gov/lau/tables.htm#cntyaa) county data.\n2. **BLS Public Data API**:\n- The BLS provides an API for developers to access various datasets, including LAUS data.\n- To use the API for LAUS data, refer to the [LAUS Series ID Formats](https://www.bls.gov/help/hlpforma.htm#LA) to construct your query.\n- API documentation and examples are available on the BLS Developers page.\n\nWhen using BLS public data API and datasets, users should adhere to the [BLS Terms of Service](https://www.bls.gov/developers/termsOfService.htm).",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3414,6 +3466,7 @@
       "description": "Five hundred paired coordinates (u, v) sampled from a bivariate uniform distribution. Centered near the\norigin with ranges spanning approximately [-0.5, 0.5] in both dimensions. The variables exhibit negligible\ncorrelation (-0.019), suggesting independence, as expected for a uniform distribution.\nA contrast to normally distributed data in `normal-2d.json`.\n",
       "licenses": [
         {
+          "name": "BSD-3-Clause",
           "path": "https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE"
         }
       ],
@@ -3455,6 +3508,7 @@
       "description": "US county boundaries represented at a 1:10,000,000 scale in \n[TopoJSON](https://github.com/topojson/topojson) format, which optimizes for \nsmaller file sizes. Similar to offerings in the TopoJSON US Atlas collection, which \nin turn is a redistribution of the Census Bureau's cartographic boundary shapefiles.\n",
       "licenses": [
         {
+          "name": "ISC",
           "title": "TopoJSON US Atlas ISC License",
           "path": "https://github.com/topojson/us-atlas/blob/master/LICENSE.md"
         }
@@ -3483,6 +3537,7 @@
       "description": "Monthly employment total in a variety of job categories from January 2006 through December 2015, \nseasonally adjusted and reported in thousands. Downloaded and reformatted on Nov. 11, 2018.\n\nIn the mid 2000s the global economy was hit by a crippling recession. One result: Massive job \nlosses across the United States. The downturn in employment, and the slow recovery in hiring that \nfollowed, was tracked each month by the Current Employment Statistics program at the U.S. Bureau \nof Labor Statistics.\n\nTotals are included for the [22 \"supersectors\"](https://download.bls.gov/pub/time.series/ce/ce.supersector)\ntracked by the BLS. The \"nonfarm\" total is the category typically used by \neconomists and journalists as a stand-in for the country's employment total.\n\nA calculated \"nonfarm_change\" column has been appended with the month-to-month change in that \nsupersector's employment. It is useful for illustrating how to make bar charts that report both \nnegative and positive values.\n",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3607,10 +3662,12 @@
       "description": "Geographical coordinates and names of U.S. state capitals, transformed using `scripts/us-state-capitals.py`. \nIncludes latitude, longitude, state name, and capital city name for all 50 U.S. states. \nCities are represented as point locations of their capitol buildings using coordinates in the \nWGS84 geographic coordinate system.\n\nAccording to [USGS]((https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map))\n> \"Map services and data downloaded from The National Map are free and in the public domain. \n> There are no restrictions; however, we request that the following acknowledgment statement \n> of the originating agency be included in products and data derived from our map services \n> when citing, copying, or reprinting: Map services and data available from U.S. \n> Geological Survey, National Geospatial Program.\"\n",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Public Domain",
           "path": "https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits"
         },
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3678,6 +3735,7 @@
       "description": "Daily weather observations from Seattle and New York.\nTransformed from NOAA data using the script `/scripts/weather.py`.\nThe categorical \"weather\" field is synthesized from multiple fields in the original dataset.\nIntended for instructional purposes.",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "U.S. Government Dataset",
           "path": "https://www.usa.gov/government-works"
         }
@@ -3760,6 +3818,7 @@
       "description": "As noted by in this protovis [example](https://mbostock.github.io/protovis/ex/wheat.html),\n\"In an 1822 letter to Parliament, [William Playfair](https://en.wikipedia.org/wiki/William_Playfair), a Scottish engineer \nwho is often credited as the founder of statistical graphics, published an elegant chart \non the price of wheat. It plots 250 years of prices alongside weekly wages and the reigning monarch. \nHe intended to demonstrate that:\n> 'never at any former period was wheat so cheap, in proportion to mechanical labour, as it is at the present time.'\"\n",
       "licenses": [
         {
+          "name": "other-pd",
           "title": "Public Domain",
           "path": "https://commons.wikimedia.org/wiki/Public_domain"
         }
@@ -3841,10 +3900,12 @@
       "description": "A 1:110,000,000-scale world map in [TopoJSON](https://github.com/topojson/topojson) format, optimized for \nweb-based visualization. The simplified geographic boundaries focus on two key elements: \nland masses and country borders with their corresponding codes. The high level of \ngeneralization removes small geographic details while maintaining recognizable global \nfeatures, making it ideal for overview maps and basic world visualizations. This format \nprovides efficient compression compared to GeoJSON, reducing file size for web use. \nPart of the widely-used TopoJSON World Atlas collection, this has become a standard \nresource for creating web-based world maps where precise boundary detail isn't required.\n",
       "licenses": [
         {
+          "name": "ISC",
           "title": "TopoJSON World Atlas ISC License",
           "path": "https://github.com/topojson/world-atlas/blob/master/LICENSE.md"
         },
         {
+          "name": "other-pd",
           "title": "Natural Earth Data Public Domain",
           "path": "https://www.naturalearthdata.com/about/terms-of-use/"
         }
@@ -3873,6 +3934,7 @@
       "description": "Postal codes mapped to their geographical coordinates (latitude/longitude in WGS84) \nand administrative hierarchies, for the United States and Puerto Rico. The GeoNames \ngeographical database provides worldwide postal code data with associated geographical \nand administrative information. \n\nHistorical snapshot first contributed to vega-datasets in 2017 and no longer current. \nAdministrative boundaries have been redrawn, counties reorganized and renamed, and postal \ncodes modified. Latitude/longitude coordinates have been updated by Geonames since this \ndata was collected. For current postal code data, refer to the main GeoNames database.",
       "licenses": [
         {
+          "name": "CC-BY-4.0",
           "title": "Creative Commons Attribution 4.0 International",
           "path": "https://creativecommons.org/licenses/by/4.0/"
         }

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2025-08-21 23:04:37 [UTC]
+`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2026-02-01 19:49:53 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 
@@ -29,9 +29,9 @@ Application icon from open-source software project. Used in [Image-based Scatter
 |:--------|:-----------------------|
 | 7-Zip   | https://www.7-zip.org/ |
 ### licenses
-| title                             | path                              |
-|:----------------------------------|:----------------------------------|
-| GNU Lesser General Public License | https://www.7-zip.org/license.txt |
+| name     | title                             | path                              |
+|:---------|:----------------------------------|:----------------------------------|
+| LGPL-2.1 | GNU Lesser General Public License | https://www.7-zip.org/license.txt |
 ## `airports`
 ### path
 airports.csv
@@ -68,9 +68,9 @@ A raster grid of global annual precipitation for the year 2016 at a resolution 1
 |:----------------------------------|:------------------------------------------------------------------------|
 | Climate Forecast System Version 2 | https://www.cpc.ncep.noaa.gov/products/people/wwang/cfsv2_fcst_history/ |
 ### licenses
-| title         | path                                |
-|:--------------|:------------------------------------|
-| Public Domain | https://www.weather.gov/disclaimer/ |
+| name     | title         | path                                |
+|:---------|:--------------|:------------------------------------|
+| other-pd | Public Domain | https://www.weather.gov/disclaimer/ |
 ## `anscombe`
 ### path
 anscombe.json
@@ -127,9 +127,9 @@ Since then it has been used to demonstrate new visualization techniques, includi
 | The Design of Experiments Reference                                                                                                                                        | https://en.wikipedia.org/wiki/The_Design_of_Experiments |
 | Wiebe, G. A., Reinbach-Welch, L., Cowan, P. R. (1940). Yields of Barley Varieties in the United States and Canada, 1932-36. United States: U.S. Department of Agriculture. | https://books.google.com/books?id=OUfxLocnpKkC&pg=PA19  |
 ### licenses
-| name                                                                                        |
-|:--------------------------------------------------------------------------------------------|
-| Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified |
+| name         | title                                                                                       |
+|:-------------|:--------------------------------------------------------------------------------------------|
+| notspecified | Dataset collected by Minnesota Agricultural Experiment Station - license status unspecified |
 ## `birdstrikes`
 ### path
 birdstrikes.csv
@@ -158,9 +158,9 @@ Records of reported wildlife strikes received by the U.S. FAA
 |:-----------------------------|:------------------------|
 | FAA Wildlife Strike Database | http://wildlife.faa.gov |
 ### licenses
-| title                   | path                                      |
-|:------------------------|:------------------------------------------|
-| U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
+| name     | title                   | path                                      |
+|:---------|:------------------------|:------------------------------------------|
+| other-pd | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
 ## `budget`
 ### path
 budget.json
@@ -247,9 +247,9 @@ Historical and forecasted federal revenue/receipts produced in 2016 by the U.S. 
 |:------------------------------------------------------------|:--------------------------------------------------------------------|
 | Office of Management and Budget - Budget FY 2016 - Receipts | https://www.govinfo.gov/app/details/BUDGET-2016-DB/BUDGET-2016-DB-3 |
 ### licenses
-| title                   | path                                      |
-|:------------------------|:------------------------------------------|
-| U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
+| name     | title                   | path                                      |
+|:---------|:------------------------|:------------------------------------------|
+| other-pd | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
 ## `budgets`
 ### path
 budgets.json
@@ -270,9 +270,9 @@ representing deficits (reaching a particularly large value of -$1.78 trillion du
 |:--------------------------------|:--------------------------------|
 | Office of Management and Budget | https://www.whitehouse.gov/omb/ |
 ### licenses
-| title                   | path                                      |
-|:------------------------|:------------------------------------------|
-| U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
+| name     | title                   | path                                      |
+|:---------|:------------------------|:------------------------------------------|
+| other-pd | U.S. Government Dataset | https://resources.data.gov/open-licenses/ |
 ## `burtin`
 ### path
 burtin.json
@@ -323,9 +323,9 @@ reads as follows:
 | Scope Magazine               | https://graphicdesignarchives.org/projects/scope-magazine-vol-iii-5/ |
 | Protovis Antibiotics Example | https://mbostock.github.io/protovis/ex/antibiotics-burtin.html       |
 ### licenses
-| title                      | path                                 |
-|:---------------------------|:-------------------------------------|
-| BSD License (via Protovis) | https://mbostock.github.io/protovis/ |
+| name         | title                      | path                                 |
+|:-------------|:---------------------------|:-------------------------------------|
+| BSD-3-Clause | BSD License (via Protovis) | https://mbostock.github.io/protovis/ |
 ## `cars`
 ### path
 cars.json
@@ -336,7 +336,7 @@ Collection of car specifications and performance metrics from various automobile
 | name             | type    |
 |:-----------------|:--------|
 | Name             | string  |
-| Miles_per_Gallon | integer |
+| Miles_per_Gallon | number  |
 | Cylinders        | integer |
 | Displacement     | number  |
 | Horsepower       | integer |
@@ -349,9 +349,9 @@ Collection of car specifications and performance metrics from various automobile
 |:-------------------------|:----------------------------------|
 | StatLib Datasets Archive | http://lib.stat.cmu.edu/datasets/ |
 ### licenses
-| title                                                                         | path                                       |
-|:------------------------------------------------------------------------------|:-------------------------------------------|
-| The original was distributed in 1982 for educational and scientific purposes. | http://lib.stat.cmu.edu/datasets/cars.desc |
+| name         | title                                                                         | path                                       |
+|:-------------|:------------------------------------------------------------------------------|:-------------------------------------------|
+| notspecified | The original was distributed in 1982 for educational and scientific purposes. | http://lib.stat.cmu.edu/datasets/cars.desc |
 ## `co2_concentration`
 ### path
 co2-concentration.csv
@@ -379,9 +379,9 @@ Only includes rows with valid data.
 | Scripps CO2 Program | https://scrippsco2.ucsd.edu/data/atmospheric_co2/primary_mlo_co2_record                                      |
 | In-situ CO2 Data    | https://scrippsco2.ucsd.edu/assets/data/atmospheric/stations/in_situ_co2/monthly/monthly_in_situ_co2_mlo.csv |
 ### licenses
-| title                            | path                                         |
-|:---------------------------------|:---------------------------------------------|
-| Creative Commons Attribution 4.0 | https://creativecommons.org/licenses/by/4.0/ |
+| name      | title                            | path                                         |
+|:----------|:---------------------------------|:---------------------------------------------|
+| CC-BY-4.0 | Creative Commons Attribution 4.0 | https://creativecommons.org/licenses/by/4.0/ |
 ## `countries`
 ### path
 countries.json
@@ -409,9 +409,9 @@ aims to "show people the big picture" rather than support detailed numeric analy
 | Gapminder Foundation - Life Expectancy | https://docs.google.com/spreadsheets/d/1RehxZjXd7_rG8v2pJYV6aY0J3LAsgUPDQnbY4dRdiSs/edit?gid=176703676#gid=176703676 |        14 |
 | Gapminder Foundation - Fertility       | https://docs.google.com/spreadsheets/d/1aLtIpAWvDGGa9k2XXEz6hZugWn0wCd5nmzaRPPjbYNA/edit?gid=176703676#gid=176703676 |        14 |
 ### licenses
-| title                                          | path                                     |
-|:-----------------------------------------------|:-----------------------------------------|
-| Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
+| name      | title                                          | path                                     |
+|:----------|:-----------------------------------------------|:-----------------------------------------|
+| CC-BY-4.0 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
 ## `crimea`
 ### path
 crimea.json
@@ -445,9 +445,9 @@ the dramatic impact of sanitary reforms, particularly in reducing preventable de
 |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | Nightingale, Florence. A contribution to the sanitary history of the British army during the late war with Russia. London : John W. Parker and Son, 1859. Table II. Table showing the Estimated Average Monthly Strength of the Army; and the Deaths and Annual Rate of Mortality per 1,000 in each month, from April 1854, to March 1856 (inclusive), in the Hospitals of the Army in the East. | https://nrs.lib.harvard.edu/urn-3:hms.count:1177146?n=21 |
 ### licenses
-| title                                                               | path                                                                                 |
-|:--------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
-| Harvard Library - Digitized Content Copyright & Viewer Terms of Use | https://library.harvard.edu/privacy-terms-use-copyright-information#digitizedcontent |
+| name         | title                                                               | path                                                                                 |
+|:-------------|:--------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
+| notspecified | Harvard Library - Digitized Content Copyright & Viewer Terms of Use | https://library.harvard.edu/privacy-terms-use-copyright-information#digitizedcontent |
 ## `disasters`
 ### path
 disasters.csv
@@ -469,10 +469,10 @@ calculating derived indicators, and adapting metadata. Deaths are reported as ab
 | EM-DAT: The Emergency Events Database                                 | https://www.emdat.be                            |
 | Hannah Ritchie, Pablo Rosado and Max Roser (2022) - Natural Disasters | https://ourworldindata.org/natural-catastrophes |
 ### licenses
-| title                                           | path                                          |
-|:------------------------------------------------|:----------------------------------------------|
-| EM-DAT terms of use                             | https://doc.emdat.be/docs/legal/terms-of-use/ |
-| Creative Commons BY license (Our World in Data) | https://creativecommons.org/licenses/by/4.0/  |
+| name         | title                                           | path                                          |
+|:-------------|:------------------------------------------------|:----------------------------------------------|
+| notspecified | EM-DAT terms of use                             | https://doc.emdat.be/docs/legal/terms-of-use/ |
+| CC-BY-4.0    | Creative Commons BY license (Our World in Data) | https://creativecommons.org/licenses/by/4.0/  |
 ## `driving`
 ### path
 driving.json
@@ -507,9 +507,9 @@ USGS Earthquake Hazards Program from January 31 to February 7, 2018 (UTC).
 |:---------------------|:---------------------------------------------------------------------------|
 | USGS Earthquake Feed | https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson |
 ### licenses
-| title              | path                                                                              |
-|:-------------------|:----------------------------------------------------------------------------------|
-| U.S. Public Domain | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
+| name     | title              | path                                                                              |
+|:---------|:-------------------|:----------------------------------------------------------------------------------|
+| other-pd | U.S. Public Domain | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
 ## `ffox`
 ### path
 ffox.png
@@ -520,31 +520,40 @@ Application icon from open-source software project. Used in [Image-based Scatter
 |:----------------|:---------------------------------|
 | Mozilla Firefox | https://www.mozilla.org/firefox/ |
 ### licenses
-| title                     | path                                                        |
-|:--------------------------|:------------------------------------------------------------|
-| Mozilla Trademark License | https://www.mozilla.org/en-US/foundation/trademarks/policy/ |
+| name         | title                     | path                                                        |
+|:-------------|:--------------------------|:------------------------------------------------------------|
+| notspecified | Mozilla Trademark License | https://www.mozilla.org/en-US/foundation/trademarks/policy/ |
 ## `flare_dependencies`
 ### path
 flare-dependencies.json
 ### description
-Indicates, with `flare.json`, relationships among classes in a software hierarchy.
+Network of class dependencies for the Flare visualization library. Each entry
+represents a directed edge where the `source` class depends on (imports) the `target` class.
+IDs correspond to those in `flare.json`.
 ### schema
     
-| name   | type    |
-|:-------|:--------|
-| source | integer |
-| target | integer |
+| name   | type    | description                                            |
+|:-------|:--------|:-------------------------------------------------------|
+| source | integer | ID of the class that has the dependency (the importer) |
+| target | integer | ID of the class being depended upon (the imported)     |
 ## `flare`
 ### path
 flare.json
 ### description
-Indicates, with `flare-dependencies.json`, relationships among classes in a software hierarchy.
+Class hierarchy of the Flare visualization library. Used with `flare-dependencies.json`
+to represent the complete package/class structure.
+
+Represents a tree structure where nodes have different fields depending on their role:
+- Root node: only `id` and `name`
+- Branch nodes: `id`, `name`, and `parent`
+- Leaf nodes: `id`, `name`, `parent`, and `size`
+
 ### schema
     
-| name   | type    |
-|:-------|:--------|
-| id     | integer |
-| name   | string  |
+| name   | type    | description                       |
+|:-------|:--------|:----------------------------------|
+| id     | integer | Unique identifier for the node    |
+| name   | string  | Name of the node in the hierarchy |
 ## `flights_10k`
 ### path
 flights-10k.json
@@ -555,13 +564,13 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 `/scripts/flights.py`
 ### schema
     
-| name        | type     |
-|:------------|:---------|
-| date        | datetime |
-| delay       | integer  |
-| distance    | integer  |
-| origin      | string   |
-| destination | string   |
+| name        | type     | format         |
+|:------------|:---------|:---------------|
+| date        | datetime | %Y/%m/%d %H:%M |
+| delay       | integer  |                |
+| distance    | integer  |                |
+| origin      | string   |                |
+| destination | string   |                |
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
@@ -626,13 +635,13 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 `/scripts/flights.py`
 ### schema
     
-| name        | type     |
-|:------------|:---------|
-| date        | datetime |
-| delay       | integer  |
-| distance    | integer  |
-| origin      | string   |
-| destination | string   |
+| name        | type     | format         |
+|:------------|:---------|:---------------|
+| date        | datetime | %Y/%m/%d %H:%M |
+| delay       | integer  |                |
+| distance    | integer  |                |
+| origin      | string   |                |
+| destination | string   |                |
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
@@ -651,13 +660,13 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 `/scripts/flights.py`
 ### schema
     
-| name        | type     |
-|:------------|:---------|
-| date        | datetime |
-| delay       | integer  |
-| distance    | integer  |
-| origin      | string   |
-| destination | string   |
+| name        | type     | format         |
+|:------------|:---------|:---------------|
+| date        | datetime | %Y/%m/%d %H:%M |
+| delay       | integer  |                |
+| distance    | integer  |                |
+| origin      | string   |                |
+| destination | string   |                |
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
@@ -676,13 +685,13 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 `/scripts/flights.py`
 ### schema
     
-| name        | type     |
-|:------------|:---------|
-| date        | datetime |
-| delay       | integer  |
-| distance    | integer  |
-| origin      | string   |
-| destination | string   |
+| name        | type     | format         |
+|:------------|:---------|:---------------|
+| date        | datetime | %Y/%m/%d %H:%M |
+| delay       | integer  |                |
+| distance    | integer  |                |
+| origin      | string   |                |
+| destination | string   |                |
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
@@ -701,13 +710,13 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 `/scripts/flights.py`
 ### schema
     
-| name        | type     |
-|:------------|:---------|
-| date        | datetime |
-| delay       | integer  |
-| distance    | integer  |
-| origin      | string   |
-| destination | string   |
+| name        | type     | format         |
+|:------------|:---------|:---------------|
+| date        | datetime | %Y/%m/%d %H:%M |
+| delay       | integer  |                |
+| distance    | integer  |                |
+| origin      | string   |                |
+| destination | string   |                |
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
@@ -720,7 +729,7 @@ that qualifying airlines report on-time performance data to BTS. Transformed usi
 ### path
 flights-airport.csv
 ### description
-Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id), 
+Flight information for the year 2008. Each record consists of an origin airport (identified by IATA id),
 a destination airport, and the count of flights along this route.
 ### schema
     
@@ -732,12 +741,11 @@ a destination airport, and the count of flights along this route.
 ### sources
 | title                                    | path                                                                                 |
 |:-----------------------------------------|:-------------------------------------------------------------------------------------|
-| U.S. Bureau of Transportation Statistics |                                                                                      |
 | U.S. Bureau of Transportation Statistics | https://www.transtats.bts.gov/DL_SelectFields.asp?gnoyr_VQ=FGJ&QO_fu146_anzr=b0-gvzr |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `football`
 ### path
 football.json
@@ -760,9 +768,9 @@ chosen divisions over the time period.
 |:-------------|:----------------------------------------------|
 | OpenFootball | https://github.com/openfootball/football.json |
 ### licenses
-| path                                                                     |
-|:-------------------------------------------------------------------------|
-| https://github.com/openfootball/football.json?tab=readme-ov-file#license |
+| name     | path                                                                     |
+|:---------|:-------------------------------------------------------------------------|
+| other-pd | https://github.com/openfootball/football.json?tab=readme-ov-file#license |
 ## `gapminder_health_income`
 ### path
 gapminder-health-income.csv
@@ -790,9 +798,9 @@ Gapminder (v30, 2023) defines per-capita income as follows:
 | Gapminder Foundation          | https://www.gapminder.org                                                                                            |
 | Gapminder GDP Per Capita Data | https://docs.google.com/spreadsheets/d/1i5AEui3WZNZqh7MQ4AKkJuCz4rRxGR_pw_9gtbcBOqQ/edit?gid=501532268#gid=501532268 |
 ### licenses
-| title                                          | path                                     |
-|:-----------------------------------------------|:-----------------------------------------|
-| Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
+| name      | title                                          | path                                     |
+|:----------|:-----------------------------------------------|:-----------------------------------------|
+| CC-BY-4.0 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
 ## `gapminder`
 ### path
 gapminder.json
@@ -840,9 +848,9 @@ Notes:
 | Gapminder Foundation - Data Geographies (Documentation)        | https://www.gapminder.org/data/geo/                                                                                    |           |
 | Gapminder Data Documentation                                   | https://www.gapminder.org/data/documentation/                                                                          |           |
 ### licenses
-| title                                          | path                                     |
-|:-----------------------------------------------|:-----------------------------------------|
-| Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
+| name      | title                                          | path                                     |
+|:----------|:-----------------------------------------------|:-----------------------------------------|
+| CC-BY-4.0 | Creative Commons Attribution 4.0 International | https://www.gapminder.org/free-material/ |
 ## `gimp`
 ### path
 gimp.png
@@ -853,9 +861,9 @@ Application icon from open-source software project. Used in [Image-based Scatter
 |:------------------|:----------------------------|
 | GIMP - About GIMP | https://www.gimp.org/about/ |
 ### licenses
-| path                                                                                       |
-|:-------------------------------------------------------------------------------------------|
-| https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it |
+| name         | path                                                                                       |
+|:-------------|:-------------------------------------------------------------------------------------------|
+| notspecified | https://www.gimp.org/docs/userfaq.html#whats-the-gimps-license-and-how-do-i-comply-with-it |
 ## `github`
 ### path
 github.csv
@@ -870,13 +878,13 @@ in a GitHub-style punchcard visualization format.
 | time   | string  | Hourly timestamp from January 1st to May 30th, 2015 |
 | count  | integer | Simulated hourly commit counts                      |
 ### sources
-| title                                 |
-|:--------------------------------------|
-| Generated using `/scripts/github.py`. |
+| title                                 | path                                                              |
+|:--------------------------------------|:------------------------------------------------------------------|
+| Generated using `/scripts/github.py`. | https://github.com/vega/vega-datasets/blob/main/scripts/github.py |
 ### licenses
-| path                                                            |
-|:----------------------------------------------------------------|
-| https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
+| name         | path                                                            |
+|:-------------|:----------------------------------------------------------------|
+| BSD-3-Clause | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
 ## `global_temp`
 ### path
 global-temp.csv
@@ -893,9 +901,9 @@ Combined Land-Surface Air and Sea-Surface Water Temperature Anomalies (Land-Ocea
 |:-----------------------------------------|:------------------------------------|
 | NASA Goddard Institute for Space Studies | https://data.giss.nasa.gov/gistemp/ |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `income`
 ### path
 income.json
@@ -921,9 +929,9 @@ but is not endorsed or certified by the Census Bureau.
 | U.S. Census Bureau American Community Survey 3-Year Data (2013) | https://www.census.gov/data/developers/data-sets/acs-3year/2013.html |
 | Census Bureau Data API User Guide                               | https://www.census.gov/data/developers/guidance/api-user-guide.html  |
 ### licenses
-| title                                   | path                                                               | name                       |
-|:----------------------------------------|:-------------------------------------------------------------------|:---------------------------|
-| U.S. Census Bureau API Terms of Service | https://www.census.gov/data/developers/about/terms-of-service.html | Census Bureau Terms of Use |
+| name       | title                                   | path                                                               |
+|:-----------|:----------------------------------------|:-------------------------------------------------------------------|
+| other-open | U.S. Census Bureau API Terms of Service | https://www.census.gov/data/developers/about/terms-of-service.html |
 ## `iowa_electricity`
 ### path
 iowa-electricity.csv
@@ -942,9 +950,9 @@ Useful for illustrating stacked area charts. Demonstrates dramatic increase in w
 |:---------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | U.S. Energy Information Administration | https://www.eia.gov/beta/electricity/data/browser/#/topic/0?agg=2,0,1&fuel=vvg&geo=00000g&sec=g&linechart=ELEC.GEN.OTH-IA-99.A~ELEC.GEN.COW-IA-99.A~ELEC.GEN.PEL-IA-99.A~ELEC.GEN.PC-IA-99.A~ELEC.GEN.NG-IA-99.A~~ELEC.GEN.NUC-IA-99.A~ELEC.GEN.HYC-IA-99.A~ELEC.GEN.AOR-IA-99.A~ELEC.GEN.HPS-IA-99.A~&columnchart=ELEC.GEN.ALL-IA-99.A&map=ELEC.GEN.ALL-IA-99.A&freq=A&start=2001&end=2017&ctype=linechart&ltype=pin&tab=overview&maptype=0&rse=0&pin= |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `jobs`
 ### path
 jobs.json
@@ -983,9 +991,9 @@ Steven Ruggles, Katie Genadek, Ronald Goeken, Josiah Grover, and Matthew Sobek. 
 |:----------|:---------------------------|----------:|
 | IPUMS USA | https://usa.ipums.org/usa/ |         6 |
 ### licenses
-| title              | path                              |
-|:-------------------|:----------------------------------|
-| IPUMS Terms of Use | https://www.ipums.org/about/terms |
+| name         | title              | path                              |
+|:-------------|:-------------------|:----------------------------------|
+| notspecified | IPUMS Terms of Use | https://www.ipums.org/about/terms |
 ## `la_riots`
 ### path
 la-riots.csv
@@ -1024,9 +1032,9 @@ and "Contains Ordnance Survey data © Crown copyright and database right [2015].
 |:-------------------------------------------------|:-------------------------------------------------------------------------|
 | Statistical GIS Boundary Files, London Datastore | https://data.london.gov.uk/dataset/statistical-gis-boundary-files-london |
 ### licenses
-| title                      | path                                                                       |
-|:---------------------------|:---------------------------------------------------------------------------|
-| UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+| name       | title                      | path                                                                       |
+|:-----------|:---------------------------|:---------------------------------------------------------------------------|
+| OGL-UK-3.0 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
 ## `london_centroids`
 ### path
 londonCentroids.json
@@ -1044,9 +1052,9 @@ Calculated from `londonBoroughs.json` using [`d3.geoCentroid`](https://d3js.org/
 |:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------|
 | [londonBoroughs.json](https://github.com/vega/vega-datasets/blob/main/data/londonBoroughs.json) from the [vega-datasets](https://github.com/vega/vega-datasets) repository | https://github.com/vega/vega-datasets/blob/main/data/londonBoroughs.json |
 ### licenses
-| title                      | path                                                                       |
-|:---------------------------|:---------------------------------------------------------------------------|
-| UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+| name       | title                      | path                                                                       |
+|:-----------|:---------------------------|:---------------------------------------------------------------------------|
+| OGL-UK-3.0 | UK Open Government License | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
 ## `london_tube_lines`
 ### path
 londonTubeLines.json
@@ -1061,9 +1069,9 @@ reflects the system as of February 4, 2018, and may not incorporate subsequent m
 |:----------------------------------------------|:----------------------------------------------------------------------------|
 | OpenStreetMap Data (processed by oobrien/vis) | https://github.com/oobrien/vis/blob/master/tubecreature/data/tfl_lines.json |
 ### licenses
-| title                                          | path                                       |
-|:-----------------------------------------------|:-------------------------------------------|
-| Open Data Commons Open Database License (ODbL) | https://opendatacommons.org/licenses/odbl/ |
+| name     | title                                          | path                                       |
+|:---------|:-----------------------------------------------|:-------------------------------------------|
+| ODbL-1.0 | Open Data Commons Open Database License (ODbL) | https://opendatacommons.org/licenses/odbl/ |
 ## `lookup_groups`
 ### path
 lookup_groups.csv
@@ -1081,9 +1089,9 @@ mapping people to groups. Used to [demonstrate](https://vega.github.io/vega-lite
 |:---------------|
 | Generated Data |
 ### licenses
-| path                                                            |
-|:----------------------------------------------------------------|
-| https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
+| name         | path                                                            |
+|:-------------|:----------------------------------------------------------------|
+| BSD-3-Clause | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
 ## `lookup_people`
 ### path
 lookup_people.csv
@@ -1103,9 +1111,9 @@ to [demonstrate](https://vega.github.io/vega-lite/examples/lookup.html) `lookup`
 |:---------------|
 | Generated Data |
 ### licenses
-| path                                                            |
-|:----------------------------------------------------------------|
-| https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
+| name         | path                                                            |
+|:-------------|:----------------------------------------------------------------|
+| BSD-3-Clause | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
 ## `miserables`
 ### path
 miserables.json
@@ -1120,9 +1128,9 @@ coappearances.
 |:-----------------------------------------------------------------------------------------------------------------|:----------------------------------------------------|
 | D. E. Knuth, The Stanford GraphBase: A Platform for Combinatorial Computing, Addison-Wesley, Reading, MA (1993). | https://www-cs-faculty.stanford.edu/~knuth/sgb.html |
 ### licenses
-| path                                      |
-|:------------------------------------------|
-| https://websites.umich.edu/~mejn/netdata/ |
+| name         | path                                      |
+|:-------------|:------------------------------------------|
+| notspecified | https://websites.umich.edu/~mejn/netdata/ |
 ## `monarchs`
 ### path
 monarchs.json
@@ -1159,36 +1167,40 @@ Source data has been verified against the kings & queens and interregnum pages o
 | The Royal Family - Kings & Queens | https://www.royal.uk/kings-and-queens-1066 |
 | The Royal Family - Interregnum    | https://www.royal.uk/interregnum-1649-1660 |
 ### licenses
-| title                             | path                                                                       |
-|:----------------------------------|:---------------------------------------------------------------------------|
-| Open Government Licence v3.0 (UK) | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+| name       | title                             | path                                                                       |
+|:-----------|:----------------------------------|:---------------------------------------------------------------------------|
+| OGL-UK-3.0 | Open Government Licence v3.0 (UK) | https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
 ## `movies`
 ### path
 movies.json
 ### description
-A collection of films and their performance metrics, including box office earnings, budgets, 
-and audience ratings. Contains known data quality issues and intentional errors, serving as a teaching 
-resource for developing data cleaning and validation skills in real-world analysis workflows.
+A collection of films and their performance metrics, including box office earnings, budgets,
+and audience ratings. Contains known data quality issues typical of real-world datasets:
+- Some movie titles with numeric names (1776, 2012, 300, etc.) are stored as JSON numbers rather than strings
+- Release dates use 'MMM DD YYYY' format rather than ISO 8601
+
+These characteristics make it suitable as a teaching resource for developing data cleaning
+and validation skills in real-world analysis workflows.
 ### schema
     
-| name                   | type    |
-|:-----------------------|:--------|
-| Title                  | string  |
-| US Gross               | integer |
-| Worldwide Gross        | integer |
-| US DVD Sales           | integer |
-| Production Budget      | integer |
-| Release Date           | date    |
-| MPAA Rating            | string  |
-| Running Time min       | integer |
-| Distributor            | string  |
-| Source                 | string  |
-| Major Genre            | string  |
-| Creative Type          | string  |
-| Director               | string  |
-| Rotten Tomatoes Rating | integer |
-| IMDB Rating            | number  |
-| IMDB Votes             | integer |
+| name                   | type    | format   |
+|:-----------------------|:--------|:---------|
+| Title                  | string  |          |
+| US Gross               | integer |          |
+| Worldwide Gross        | integer |          |
+| US DVD Sales           | integer |          |
+| Production Budget      | integer |          |
+| Release Date           | date    | %b %d %Y |
+| MPAA Rating            | string  |          |
+| Running Time min       | integer |          |
+| Distributor            | string  |          |
+| Source                 | string  |          |
+| Major Genre            | string  |          |
+| Creative Type          | string  |          |
+| Director               | string  |          |
+| Rotten Tomatoes Rating | integer |          |
+| IMDB Rating            | number  |          |
+| IMDB Votes             | integer |          |
 ## `normal_2d`
 ### path
 normal-2d.json
@@ -1214,9 +1226,9 @@ A contrast to uniformly distributed data in `uniform-2d.json`
 |:---------------|
 | Generated Data |
 ### licenses
-| path                                                            |
-|:----------------------------------------------------------------|
-| https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
+| name         | path                                                            |
+|:-------------|:----------------------------------------------------------------|
+| BSD-3-Clause | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
 ## `obesity`
 ### path
 obesity.json
@@ -1235,9 +1247,9 @@ Originally [Behavioral Risk Factor Surveillance System (BRFSS)](https://www.cdc.
 |:---------|:---------------------------------------------------|
 | Protovis | https://mbostock.github.io/protovis/ex/us_stats.js |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `ohlc`
 ### path
 ohlc.json
@@ -1338,42 +1350,42 @@ Additionally, the FEC's Github [repository](https://github.com/fecgov/FEC) state
 > [FEC.gov](https://www.fec.gov/).
 ### schema
     
-| name                                          | type    |
-|:----------------------------------------------|:--------|
-| Candidate_Identification                      | string  |
-| Candidate_Name                                | string  |
-| Incumbent_Challenger_Status                   | string  |
-| Party_Code                                    | integer |
-| Party_Affiliation                             | string  |
-| Total_Receipts                                | number  |
-| Transfers_from_Authorized_Committees          | integer |
-| Total_Disbursements                           | number  |
-| Transfers_to_Authorized_Committees            | number  |
-| Beginning_Cash                                | number  |
-| Ending_Cash                                   | number  |
-| Contributions_from_Candidate                  | number  |
-| Loans_from_Candidate                          | integer |
-| Other_Loans                                   | integer |
-| Candidate_Loan_Repayments                     | number  |
-| Other_Loan_Repayments                         | integer |
-| Debts_Owed_By                                 | number  |
-| Total_Individual_Contributions                | integer |
-| Candidate_State                               | string  |
-| Candidate_District                            | integer |
-| Contributions_from_Other_Political_Committees | integer |
-| Contributions_from_Party_Committees           | integer |
-| Coverage_End_Date                             | date    |
-| Refunds_to_Individuals                        | integer |
-| Refunds_to_Committees                         | integer |
+| name                                          | type    | format   |
+|:----------------------------------------------|:--------|:---------|
+| Candidate_Identification                      | string  |          |
+| Candidate_Name                                | string  |          |
+| Incumbent_Challenger_Status                   | string  |          |
+| Party_Code                                    | integer |          |
+| Party_Affiliation                             | string  |          |
+| Total_Receipts                                | number  |          |
+| Transfers_from_Authorized_Committees          | integer |          |
+| Total_Disbursements                           | number  |          |
+| Transfers_to_Authorized_Committees            | number  |          |
+| Beginning_Cash                                | number  |          |
+| Ending_Cash                                   | number  |          |
+| Contributions_from_Candidate                  | number  |          |
+| Loans_from_Candidate                          | integer |          |
+| Other_Loans                                   | integer |          |
+| Candidate_Loan_Repayments                     | number  |          |
+| Other_Loan_Repayments                         | integer |          |
+| Debts_Owed_By                                 | number  |          |
+| Total_Individual_Contributions                | integer |          |
+| Candidate_State                               | string  |          |
+| Candidate_District                            | integer |          |
+| Contributions_from_Other_Political_Committees | integer |          |
+| Contributions_from_Party_Committees           | integer |          |
+| Coverage_End_Date                             | date    | %m/%d/%Y |
+| Refunds_to_Individuals                        | integer |          |
+| Refunds_to_Committees                         | integer |          |
 ### sources
 | title                                 | path                                                |
 |:--------------------------------------|:----------------------------------------------------|
 | Federal Election Commission Bulk Data | https://www.fec.gov/data/browse-data/?tab=bulk-data |
 | OpenFEC API                           | https://api.open.fec.gov/developers/                |
 ### licenses
-| title                               | path                                               |
-|:------------------------------------|:---------------------------------------------------|
-| Creative Commons Zero 1.0 Universal | https://creativecommons.org/publicdomain/zero/1.0/ |
+| name    | title                               | path                                               |
+|:--------|:------------------------------------|:---------------------------------------------------|
+| CC0-1.0 | Creative Commons Zero 1.0 Universal | https://creativecommons.org/publicdomain/zero/1.0/ |
 ## `population`
 ### path
 population.json
@@ -1402,9 +1414,9 @@ http://doi.org/10.18128/D010.V6.0
 |:----------|:---------------------------|
 | IPUMS USA | https://usa.ipums.org/usa/ |
 ### licenses
-| title              | path                              |
-|:-------------------|:----------------------------------|
-| IPUMS Terms of Use | https://www.ipums.org/about/terms |
+| name         | title              | path                              |
+|:-------------|:-------------------|:----------------------------------|
+| notspecified | IPUMS Terms of Use | https://www.ipums.org/about/terms |
 ## `population_engineers_hurricanes`
 ### path
 population_engineers_hurricanes.csv
@@ -1427,9 +1439,9 @@ Per-state population, number of engineers, and hurricanes. Used in Vega-Lite exa
 | American Community Survey          | https://factfinder.census.gov/faces/tableservices/jsf/pages/productview.xhtml?pid=ACS_07_3YR_S1901&prodType=table |
 | NOAA National Climatic Data Center | https://www.ncdc.noaa.gov/cdo-web/datatools/records                                                               |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `seattle_weather_hourly_normals`
 ### path
 seattle-weather-hourly-normals.csv
@@ -1452,9 +1464,9 @@ and updated the format to be easier to parse.
 |:------------------------------------------|:----------------------------------------------------|
 | NOAA National Climatic Data Center (NCDC) | https://www.ncdc.noaa.gov/cdo-web/datatools/normals |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `seattle_weather`
 ### path
 seattle-weather.csv
@@ -1477,9 +1489,9 @@ This data is intended for instructional purposes.
 |:-----------------------------------|:----------------------------------------------------|
 | NOAA National Climatic Data Center | https://www.ncdc.noaa.gov/cdo-web/datatools/records |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `sp500_2000`
 ### path
 sp500-2000.csv
@@ -1510,10 +1522,10 @@ the dot-com bubble burst (2000-2002), the mid-2000s bull market, and the 2008 fi
 
 ### schema
     
-| name   | type   | description                                            |
-|:-------|:-------|:-------------------------------------------------------|
-| date   | date   | Date of monthly observation in the format 'MMM D YYYY' |
-| price  | number | Closing price of the S&P 500 index for the given month |
+| name   | type   | description                                            | format   |
+|:-------|:-------|:-------------------------------------------------------|:---------|
+| date   | date   | Date of monthly observation in the format 'MMM D YYYY' | %b %d %Y |
+| price  | number | Closing price of the S&P 500 index for the given month |          |
 ## `species`
 ### path
 species.csv
@@ -1548,9 +1560,9 @@ for zonal statistics.
 | USGS Gap Analysis Project (GAP) Species Habitat Maps        | https://www.usgs.gov/programs/gap-analysis-project                                          |
 | US Census Bureau Cartographic Boundary Files (1:10,000,000) | https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `stocks`
 ### path
 stocks.csv
@@ -1558,11 +1570,11 @@ stocks.csv
 Monthly stock prices for five companies from 2000 to 2010.
 ### schema
     
-| name   | type   |
-|:-------|:-------|
-| symbol | string |
-| date   | date   |
-| price  | number |
+| name   | type   | format   |
+|:-------|:-------|:---------|
+| symbol | string |          |
+| date   | date   | %b %d %Y |
+| price  | number |          |
 ## `udistrict`
 ### path
 udistrict.json
@@ -1612,9 +1624,9 @@ See full BLS [terms of service](https://www.bls.gov/developers/termsOfService.ht
 | BLS LAUS Data Tools                          | https://www.bls.gov/lau/data.htm                 |
 | Bureau of Labor Statistics Table A-31        | https://www.bls.gov/web/empsit/cpseea31.htm      |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `unemployment`
 ### path
 unemployment.tsv
@@ -1657,9 +1669,9 @@ When using BLS public data API and datasets, users should adhere to the [BLS Ter
 | BLS Developers API      | https://www.bls.gov/developers/           |
 | BLS Handbook of Methods | https://www.bls.gov/opub/hom/lau/home.htm |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `uniform_2d`
 ### path
 uniform-2d.json
@@ -1680,9 +1692,9 @@ A contrast to normally distributed data in `normal-2d.json`.
 |:---------------|
 | Generated Data |
 ### licenses
-| path                                                            |
-|:----------------------------------------------------------------|
-| https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
+| name         | path                                                            |
+|:-------------|:----------------------------------------------------------------|
+| BSD-3-Clause | https://github.com/vega/vega-datasets/blob/main/scripts/LICENSE |
 ## `us_10m`
 ### path
 us-10m.json
@@ -1698,9 +1710,9 @@ in turn is a redistribution of the Census Bureau's cartographic boundary shapefi
 | TopoJSON US Atlas                            | https://github.com/topojson/us-atlas                                                        |
 | US Census Bureau Cartographic Boundary FIles | https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html |
 ### licenses
-| title                         | path                                                        |
-|:------------------------------|:------------------------------------------------------------|
-| TopoJSON US Atlas ISC License | https://github.com/topojson/us-atlas/blob/master/LICENSE.md |
+| name   | title                         | path                                                        |
+|:-------|:------------------------------|:------------------------------------------------------------|
+| ISC    | TopoJSON US Atlas ISC License | https://github.com/topojson/us-atlas/blob/master/LICENSE.md |
 ## `us_employment`
 ### path
 us-employment.csv
@@ -1754,9 +1766,9 @@ negative and positive values.
 |:--------------------------------------------------------------|:-------------------------|
 | U.S. Bureau of Labor Statistics Current Employment Statistics | https://www.bls.gov/ces/ |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `us_state_capitals`
 ### path
 us-state-capitals.json
@@ -1786,10 +1798,10 @@ According to [USGS]((https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-s
 |:----------------------------------------------------------------------|:-----------------------------------------------------------------------|
 | U.S. Geological Survey National Geospatial Program - The National Map | https://www.usgs.gov/programs/national-geospatial-program/national-map |
 ### licenses
-| title                   | path                                                                              |
-|:------------------------|:----------------------------------------------------------------------------------|
-| U.S. Public Domain      | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
-| U.S. Government Dataset | https://www.usa.gov/government-works                                              |
+| name     | title                   | path                                                                              |
+|:---------|:------------------------|:----------------------------------------------------------------------------------|
+| other-pd | U.S. Public Domain      | https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits |
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works                                              |
 ## `volcano`
 ### path
 volcano.json
@@ -1826,9 +1838,9 @@ Intended for instructional purposes.
 |:-------------------------|:-------------------------------------------------------|
 | NOAA Climate Data Online | http://www.ncdc.noaa.gov/cdo-web/datatools/findstation |
 ### licenses
-| title                   | path                                 |
-|:------------------------|:-------------------------------------|
-| U.S. Government Dataset | https://www.usa.gov/government-works |
+| name     | title                   | path                                 |
+|:---------|:------------------------|:-------------------------------------|
+| other-pd | U.S. Government Dataset | https://www.usa.gov/government-works |
 ## `weekly_weather`
 ### path
 weekly-weather.json
@@ -1861,9 +1873,9 @@ He intended to demonstrate that:
 |:--------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1822 Playfair Chart | https://commons.wikimedia.org/wiki/File:Chart_Showing_at_One_View_the_Price_of_the_Quarter_of_Wheat,_and_Wages_of_Labour_by_the_Week,_from_1565_to_1821.png |
 ### licenses
-| title         | path                                             |
-|:--------------|:-------------------------------------------------|
-| Public Domain | https://commons.wikimedia.org/wiki/Public_domain |
+| name     | title         | path                                             |
+|:---------|:--------------|:-------------------------------------------------|
+| other-pd | Public Domain | https://commons.wikimedia.org/wiki/Public_domain |
 ## `windvectors`
 ### path
 windvectors.csv
@@ -1897,10 +1909,10 @@ resource for creating web-based world maps where precise boundary detail isn't r
 | TopoJSON World Atlas (Likely original source, processed from Natural Earth data) | https://github.com/topojson/world-atlas                                                  |
 | Natural Earth Data - Admin 0 Countries (1:110m)                                  | https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/ |
 ### licenses
-| title                            | path                                                           |
-|:---------------------------------|:---------------------------------------------------------------|
-| TopoJSON World Atlas ISC License | https://github.com/topojson/world-atlas/blob/master/LICENSE.md |
-| Natural Earth Data Public Domain | https://www.naturalearthdata.com/about/terms-of-use/           |
+| name     | title                            | path                                                           |
+|:---------|:---------------------------------|:---------------------------------------------------------------|
+| ISC      | TopoJSON World Atlas ISC License | https://github.com/topojson/world-atlas/blob/master/LICENSE.md |
+| other-pd | Natural Earth Data Public Domain | https://www.naturalearthdata.com/about/terms-of-use/           |
 ## `zipcodes`
 ### path
 zipcodes.csv
@@ -1929,6 +1941,6 @@ data was collected. For current postal code data, refer to the main GeoNames dat
 |:----------------------|:------------------------------------------|
 | GeoNames Postal Codes | https://download.geonames.org/export/zip/ |
 ### licenses
-| title                                          | path                                         |
-|:-----------------------------------------------|:---------------------------------------------|
-| Creative Commons Attribution 4.0 International | https://creativecommons.org/licenses/by/4.0/ |
+| name      | title                                          | path                                         |
+|:----------|:-----------------------------------------------|:---------------------------------------------|
+| CC-BY-4.0 | Creative Commons Attribution 4.0 International | https://creativecommons.org/licenses/by/4.0/ |

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2026-02-01 19:49:53 [UTC]
+`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2026-02-02 02:05:43 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 
@@ -532,10 +532,10 @@ represents a directed edge where the `source` class depends on (imports) the `ta
 IDs correspond to those in `flare.json`.
 ### schema
     
-| name   | type    | description                                            |
-|:-------|:--------|:-------------------------------------------------------|
-| source | integer | ID of the class that has the dependency (the importer) |
-| target | integer | ID of the class being depended upon (the imported)     |
+| name   | type    | description                                            | constraints        |
+|:-------|:--------|:-------------------------------------------------------|:-------------------|
+| source | integer | ID of the class that has the dependency (the importer) | {'required': True} |
+| target | integer | ID of the class being depended upon (the imported)     | {'required': True} |
 ## `flare`
 ### path
 flare.json
@@ -550,10 +550,10 @@ Represents a tree structure where nodes have different fields depending on their
 
 ### schema
     
-| name   | type    | description                       |
-|:-------|:--------|:----------------------------------|
-| id     | integer | Unique identifier for the node    |
-| name   | string  | Name of the node in the hierarchy |
+| name   | type    | description                       | constraints        |
+|:-------|:--------|:----------------------------------|:-------------------|
+| id     | integer | Unique identifier for the node    | {'required': True} |
+| name   | string  | Name of the node in the hierarchy | {'required': True} |
 ## `flights_10k`
 ### path
 flights-10k.json

--- a/datapackage.md
+++ b/datapackage.md
@@ -1,5 +1,5 @@
 # vega-datasets
-`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2026-02-02 02:05:43 [UTC]
+`3.2.1` | [GitHub](git+http://github.com/vega/vega-datasets.git) | 2026-02-02 13:19:39 [UTC]
 
 Common repository for example datasets used by Vega related projects. 
 BSD-3-Clause license applies only to package code and infrastructure. Users should verify their use of datasets 
@@ -1304,9 +1304,9 @@ variations between species and sexual dimorphism in Antarctic penguins.
 | Palmer Station Antarctica LTER      | https://pallter.marine.rutgers.edu/      |
 | Allison Horst's Penguins Repository | https://github.com/allisonhorst/penguins |
 ### licenses
-| name              | path                                                                        |
-|:------------------|:----------------------------------------------------------------------------|
-| CC0 1.0 Universal | https://github.com/allisonhorst/palmerpenguins?tab=CC0-1.0-1-ov-file#readme |
+| name    | title                               | path                                                                        |
+|:--------|:------------------------------------|:----------------------------------------------------------------------------|
+| CC0-1.0 | Creative Commons Zero 1.0 Universal | https://github.com/allisonhorst/palmerpenguins?tab=CC0-1.0-1-ov-file#readme |
 ## `platformer_terrain`
 ### path
 platformer-terrain.json


### PR DESCRIPTION
 - Add CKAN license identifiers (`name` field) to all resource licenses for machine-readable compliance
  - Add explicit field schemas for `flare.json` and `flare-dependencies.json` with required field constraints
  - Add datetime format strings (e.g., `%Y/%m/%d %H:%M`) for validation compatibility with date fields (e.g. in validating with frictionless-ts)
  - Correct field types where inferred types didn't match actual data (e.g., `Miles_per_Gallon` as number)
  - Improve resource descriptions for clarity and accuracy
  - Update CONTRIBUTING.md: `uvx` → `uv run` for lockfile-consistent tool versions
  - Fix duplicate source entry for flights-airport.csv

**Note:** Some issues with Frictionless Data v2 validation tooling (Python and/or TypeScript) will need to be resolved before validation can be incorporated into this repo's CI.