### PR TITLE
ci: run datapackage validation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
         run: npm ci
 
       - run: npm run build
+
+      - name: Validate datapackage
+        run: uv run pytest tests/ -v --run-slow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
       - run: npm run build
 
       - name: Validate datapackage
-        run: uv run pytest tests/ -v --run-slow
+        run: uv run pytest tests/ -v --runslow --limit-rows 250000

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,14 +195,18 @@ uv run --group dev pytest tests/
 
 # Slow tier — frictionless schema and row validation per resource.
 # Default is full read; flights-3m.parquet (~3M rows) takes minutes.
-uv run --group dev pytest tests/ --run-slow
+uv run --group dev pytest tests/ --runslow
 
-# Slow tier with a row cap — useful for quick iteration.
-uv run --group dev pytest tests/ --run-slow --limit-rows 100000
+# Slow tier with a row cap — matches what CI runs; lower for tighter iteration.
+uv run --group dev pytest tests/ --runslow --limit-rows 250000
 ```
 
-Not run in CI. The slow tier is the comprehensive validation step; the
-fast tier alone does not exercise frictionless schemas.
+CI runs the slow tier with `--limit-rows 250000`: `flights_3m`'s ~3M
+rows are sampled, every other resource is below the cap and validates
+in full. The fast tier is implicitly covered too — `npm run build`
+regenerates `datapackage.json` from on-disk data before the slow tier
+runs, so any byte/hash drift would surface either there or in the slow
+tier's schema validation.
 
 Resources whose schema/row failures are known and non-actionable (for
 example, `movies` whose schema is intentionally aspirational, or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ geo-species = [
 
 [tool.pytest.ini_options]
 markers = [
-  "slow: full schema/row validation via frictionless; opt in with --run-slow",
+  "slow: full schema/row validation via frictionless; opt in with --runslow",
 ]
 testpaths = ["tests"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Pytest config: ``--run-slow`` and ``--limit-rows`` CLI options.
+Pytest config: ``--runslow`` and ``--limit-rows`` CLI options.
 
 The ``slow`` marker is registered in ``pyproject.toml``
 (``[tool.pytest.ini_options].markers``), matching the convention used in
@@ -16,7 +16,7 @@ import pytest
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
-        "--run-slow",
+        "--runslow",
         action="store_true",
         default=False,
         help="Run @pytest.mark.slow tests (frictionless schema/row validation).",
@@ -26,7 +26,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=None,
         help=(
-            "Cap row reads in --run-slow tests at N rows per resource. "
+            "Cap row reads in --runslow tests at N rows per resource. "
             "Default is unlimited (full read). Use a small N for quick "
             "iteration; flights-3m takes minutes at full read."
         ),
@@ -41,10 +41,10 @@ def schema_limit_rows(request: pytest.FixtureRequest) -> int | None:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Skip ``slow`` items unless ``--run-slow`` was passed."""
-    if config.getoption("--run-slow"):
+    """Skip ``slow`` items unless ``--runslow`` was passed."""
+    if config.getoption("--runslow"):
         return
-    skip_slow = pytest.mark.skip(reason="opt in with --run-slow")
+    skip_slow = pytest.mark.skip(reason="opt in with --runslow")
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -9,9 +9,9 @@ Two tiers:
   tabular JSON / arrow / parquet; hash-count supports only md5 and
   sha256, descriptor uses sha1).
 
-* Slow (``pytest --run-slow``) — frictionless schema and row validation
+* Slow (``pytest --runslow``) — frictionless schema and row validation
   per resource. Multi-minute on flights-3m at full read; opt in via the
-  ``--run-slow`` flag and pass ``--limit-rows N`` to cap row reads
+  ``--runslow`` flag and pass ``--limit-rows N`` to cap row reads
   during iteration. Default is full read.
 
 Resources whose schema/row check is known-broken upstream (``movies``
@@ -80,6 +80,7 @@ def git_blob_sha1(path: Path) -> str:
 
 @pytest.mark.parametrize("resource", _RESOURCES, ids=_RESOURCE_IDS)
 def test_file_exists(resource: dict) -> None:
+    """Catch descriptors that point at a missing or relocated data file."""
     assert "path" in resource, (
         f"descriptor regression: resource {resource.get('name')!r} has no 'path'"
     )
@@ -89,6 +90,7 @@ def test_file_exists(resource: dict) -> None:
 
 @pytest.mark.parametrize("resource", _RESOURCES, ids=_RESOURCE_IDS)
 def test_bytes_match(resource: dict) -> None:
+    """Catch on-disk edits where `bytes` in the descriptor wasn't regenerated."""
     assert "bytes" in resource, (
         f"descriptor regression: 'bytes' missing for {resource['name']!r}"
     )
@@ -102,6 +104,12 @@ def test_bytes_match(resource: dict) -> None:
 
 @pytest.mark.parametrize("resource", _RESOURCES, ids=_RESOURCE_IDS)
 def test_sha1_matches_git_blob(resource: dict) -> None:
+    """
+    Catch on-disk edits where `hash` in the descriptor wasn't regenerated.
+
+    Uses git's blob SHA-1 so the recorded hash matches `git ls-tree` —
+    catches edits that change content without changing file size.
+    """
     declared = resource.get("hash", "")
     assert declared, f"descriptor regression: 'hash' missing for {resource['name']!r}"
     assert declared.startswith("sha1:"), (


### PR DESCRIPTION
Wires the pytest validator from #782 into the existing `Test` workflow, so dataset-vs-descriptor drift fails CI on every PR rather than slipping through.

## What this validates

"Validating a datapackage" can mean a few different things. Here's what this PR does and doesn't cover:

**What this PR covers — checking that every data file still matches what `datapackage.json` says about it.**

Two tiers:
- *Fast (runs by default, under a second):* every file exists, is the size we recorded, and has the content we recorded. Catches "someone edited a CSV and forgot to regenerate `datapackage.json`."
- *Slow (`--runslow`, ~32s in CI):* every column matches its declared type, required cells aren't missing, declared limits aren't violated. Catches "a data refresh added `N/A` text into a column we said was numbers."

**What this PR doesn't cover:**
- **Whether `datapackage.json` itself follows the Data Package format** (missing required fields, values that don't match the spec's allowed list). Tracked as a follow-up in #785, with the deferral reason and concrete unblock path documented there. Briefly: a strict v2 schema check fails today on 12 of our 73 resources (`type: "json"` or `"file"`, both rejected by the v2 enum which only permits `"table"`); the cleanest path is upstream [frictionlessdata/datapackage#937](https://github.com/frictionlessdata/datapackage/issues/937) formalizing JSON Data Resource support. [`check-datapackage`](https://check-datapackage.seedcase-project.org/) (from the seedcase-project; mentioned by @joelostblom on vega/altair#3946) is the natural tool for that follow-up.

## Why `--limit-rows 250000`

`flights_3m.parquet` is the only resource above ~200K rows; the next largest (`flights_200k_*`) sit right at the cap. Capping at 250K leaves every other resource fully validated and cuts CI from ~4m43s to ~40s. Confirmed with @domoritz it is OK here to validate a sample.

## Why `--runslow` (was `--run-slow`)
Matches the [pytest docs example](https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option). Updated in `tests/conftest.py`, `pyproject.toml`, the `tests/test_datapackage.py` docstring, and `CONTRIBUTING.md` vs initial commit.

## Why we drive [frictionless-py](https://github.com/frictionlessdata/frictionless-py) from pytest instead of using its CLI directly

Our tests import `frictionless.Package` and `frictionless.Checklist` and call `.validate()` per resource. The alternative would be shelling out to `frictionless validate datapackage.json`. We don't, because of three frictionless gaps (as of `frictionless` 5.19.0) and three workflow needs the CLI doesn't satisfy:

- `byte-count` returns `None` for tabular JSON / arrow / parquet — roughly half our resources would silently skip byte verification.
- `hash-count` only supports md5 and sha256; our descriptor uses sha1 (git-blob compatible).
- `Checklist.skip_errors` is silently ignored on the parallel code path, so we pass `parallel=False`.
- We need a per-resource strict `xfail` allowlist for `movies` (intentional pedagogical quirks) and `flights_200k_arrow` (no upstream parser). If upstream ever fixes them, the tests flip XFAIL → XPASS and prompt allowlist removal.
- We want a fast/slow tier split — bare `pytest` should stay sub-second for the inner loop.
- Our descriptor uses bare filenames (`path: "cars.json"`) instead of the v2-required descriptor-relative paths; CLI invocation would need the same `basepath` workaround anyway. The non-conformance is tracked in #758, and vega/altair#3946 is the cross-repo coordination ask to make altair handle both path formats during migration.

We use frictionless's validation engine (`Checklist`, `Package.validate`); pytest provides the harness, parametrization, fast/slow split, xfail tracking, and CI integration.

## Test plan

- [x] Local: `uv run pytest tests/ -v --runslow --limit-rows 250000` → 290 passed, 2 xfailed in ~32s
- [x] Local: `uv run pytest tests/ -v` (fast tier alone) → 219 passed, 73 skipped in <1s
- [x] CI run matches local outcomes
- [x] runs in under 2 minutes
